### PR TITLE
feat(schemas): implement contract schemas for agent communication

### DIFF
--- a/.opencode/command/commit.md
+++ b/.opencode/command/commit.md
@@ -1,5 +1,5 @@
 ---
-model: claude-sonnet-4-20250514
+model: anthropic/claude-opus-4-5
 ---
 
 # Commit Changes

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+/**
+ * Session ID - UUID format string
+ */
+export const SessionIdSchema = z.string().uuid()
+export type SessionId = z.infer<typeof SessionIdSchema>
+
+/**
+ * Timestamp - ISO 8601 datetime string
+ */
+export const TimestampSchema = z.string().datetime()
+export type Timestamp = z.infer<typeof TimestampSchema>
+
+/**
+ * Agent ID - non-empty string identifier for agents
+ */
+export const AgentIdSchema = z.string().min(1)
+export type AgentId = z.infer<typeof AgentIdSchema>
+
+/**
+ * Base envelope fields shared by all messages
+ */
+export const BaseEnvelopeSchema = z
+  .object({
+    session_id: SessionIdSchema,
+    timestamp: TimestampSchema,
+  })
+  .strict()
+
+export type BaseEnvelope = z.infer<typeof BaseEnvelopeSchema>

--- a/src/schemas/errors.ts
+++ b/src/schemas/errors.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+/**
+ * Error codes for agent communication failures
+ */
+export const ErrorCode = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  UNKNOWN_AGENT: 'UNKNOWN_AGENT',
+  SESSION_NOT_FOUND: 'SESSION_NOT_FOUND',
+  AGENT_ERROR: 'AGENT_ERROR',
+  TIMEOUT: 'TIMEOUT',
+} as const
+
+export const ErrorCodeSchema = z.enum([
+  'VALIDATION_ERROR',
+  'UNKNOWN_AGENT',
+  'SESSION_NOT_FOUND',
+  'AGENT_ERROR',
+  'TIMEOUT',
+])
+
+export type ErrorCode = z.infer<typeof ErrorCodeSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,75 @@
 // Contract schemas for Orca agent communication
-// TODO: Implement discriminated union schemas for message types
 
-export {}
+// Error codes
+export { ErrorCode, ErrorCodeSchema } from './errors'
+export type { ErrorCode as ErrorCodeType } from './errors'
+
+// Common primitives
+export {
+  AgentIdSchema,
+  BaseEnvelopeSchema,
+  SessionIdSchema,
+  TimestampSchema,
+} from './common'
+export type {
+  AgentId,
+  BaseEnvelope,
+  SessionId,
+  Timestamp,
+} from './common'
+
+// Payload schemas
+export {
+  AnswerPayloadSchema,
+  EscalationOptionSchema,
+  EscalationPayloadSchema,
+  FailurePayloadSchema,
+  InterruptPayloadSchema,
+  PlanPayloadSchema,
+  PlanStepSchema,
+  QuestionPayloadSchema,
+  ResultPayloadSchema,
+  TaskPayloadSchema,
+  UserInputPayloadSchema,
+} from './payloads'
+export type {
+  AnswerPayload,
+  EscalationOption,
+  EscalationPayload,
+  FailurePayload,
+  InterruptPayload,
+  PlanPayload,
+  PlanStep,
+  QuestionPayload,
+  ResultPayload,
+  TaskPayload,
+  UserInputPayload,
+} from './payloads'
+
+// Message schemas
+export {
+  AnswerMessageSchema,
+  EscalationMessageSchema,
+  FailureMessageSchema,
+  InterruptMessageSchema,
+  MessageEnvelopeSchema,
+  PlanMessageSchema,
+  QuestionMessageSchema,
+  ResultMessageSchema,
+  TaskMessageSchema,
+  UserInputMessageSchema,
+} from './messages'
+
+export type {
+  AnswerMessage,
+  EscalationMessage,
+  FailureMessage,
+  InterruptMessage,
+  MessageEnvelope,
+  MessageType,
+  PlanMessage,
+  QuestionMessage,
+  ResultMessage,
+  TaskMessage,
+  UserInputMessage,
+} from './messages'

--- a/src/schemas/messages.ts
+++ b/src/schemas/messages.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod'
+import { BaseEnvelopeSchema } from './common'
+import {
+  AnswerPayloadSchema,
+  EscalationPayloadSchema,
+  FailurePayloadSchema,
+  InterruptPayloadSchema,
+  PlanPayloadSchema,
+  QuestionPayloadSchema,
+  ResultPayloadSchema,
+  TaskPayloadSchema,
+  UserInputPayloadSchema,
+} from './payloads'
+
+/**
+ * Task message - Orca assigns work to a specialist agent
+ */
+export const TaskMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('task'),
+  payload: TaskPayloadSchema,
+}).strict()
+
+export type TaskMessage = z.infer<typeof TaskMessageSchema>
+
+/**
+ * Result message - Specialist returns completed work
+ */
+export const ResultMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('result'),
+  payload: ResultPayloadSchema,
+}).strict()
+
+export type ResultMessage = z.infer<typeof ResultMessageSchema>
+
+/**
+ * Plan message - Strategist returns an execution plan
+ */
+export const PlanMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('plan'),
+  payload: PlanPayloadSchema,
+}).strict()
+
+export type PlanMessage = z.infer<typeof PlanMessageSchema>
+
+/**
+ * Answer message - Response to a question
+ */
+export const AnswerMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('answer'),
+  payload: AnswerPayloadSchema,
+}).strict()
+
+export type AnswerMessage = z.infer<typeof AnswerMessageSchema>
+
+/**
+ * Question message - Agent asks for clarification
+ */
+export const QuestionMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('question'),
+  payload: QuestionPayloadSchema,
+}).strict()
+
+export type QuestionMessage = z.infer<typeof QuestionMessageSchema>
+
+/**
+ * Escalation message - Agent escalates to Orca for a decision
+ */
+export const EscalationMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('escalation'),
+  payload: EscalationPayloadSchema,
+}).strict()
+
+export type EscalationMessage = z.infer<typeof EscalationMessageSchema>
+
+/**
+ * User input message - User provides input
+ */
+export const UserInputMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('user_input'),
+  payload: UserInputPayloadSchema,
+}).strict()
+
+export type UserInputMessage = z.infer<typeof UserInputMessageSchema>
+
+/**
+ * Interrupt message - User interrupts execution
+ */
+export const InterruptMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('interrupt'),
+  payload: InterruptPayloadSchema,
+}).strict()
+
+export type InterruptMessage = z.infer<typeof InterruptMessageSchema>
+
+/**
+ * Failure message - Agent reports a failure
+ */
+export const FailureMessageSchema = BaseEnvelopeSchema.extend({
+  type: z.literal('failure'),
+  payload: FailurePayloadSchema,
+}).strict()
+
+export type FailureMessage = z.infer<typeof FailureMessageSchema>
+
+/**
+ * Message envelope - Discriminated union of all message types
+ */
+export const MessageEnvelopeSchema = z.discriminatedUnion('type', [
+  TaskMessageSchema,
+  ResultMessageSchema,
+  PlanMessageSchema,
+  AnswerMessageSchema,
+  QuestionMessageSchema,
+  EscalationMessageSchema,
+  UserInputMessageSchema,
+  InterruptMessageSchema,
+  FailureMessageSchema,
+])
+
+export type MessageEnvelope = z.infer<typeof MessageEnvelopeSchema>
+
+/**
+ * Message type literal union
+ */
+export type MessageType = MessageEnvelope['type']

--- a/src/schemas/payloads.ts
+++ b/src/schemas/payloads.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import { AgentIdSchema, SessionIdSchema } from './common'
+import { ErrorCodeSchema } from './errors'
+
+/**
+ * Task payload - Orca assigns work to a specialist agent
+ */
+export const TaskPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    prompt: z.string().min(1),
+    context: z.record(z.unknown()).optional(),
+    parent_session_id: SessionIdSchema.optional(),
+  })
+  .strict()
+
+export type TaskPayload = z.infer<typeof TaskPayloadSchema>
+
+/**
+ * Result payload - Specialist returns completed work
+ */
+export const ResultPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    content: z.string(),
+    artifacts: z.array(z.string()).optional(),
+  })
+  .strict()
+
+export type ResultPayload = z.infer<typeof ResultPayloadSchema>
+
+/**
+ * Plan step schema
+ */
+export const PlanStepSchema = z
+  .object({
+    description: z.string().min(1),
+    command: z.string().optional(),
+  })
+  .strict()
+
+export type PlanStep = z.infer<typeof PlanStepSchema>
+
+/**
+ * Plan payload - Strategist returns an execution plan
+ */
+export const PlanPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    goal: z.string().min(1),
+    steps: z.array(PlanStepSchema).min(1),
+    assumptions: z.array(z.string()).optional(),
+    files_touched: z.array(z.string()).optional(),
+  })
+  .strict()
+
+export type PlanPayload = z.infer<typeof PlanPayloadSchema>
+
+/**
+ * Answer payload - Response to a question
+ */
+export const AnswerPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    content: z.string(),
+    sources: z.array(z.string()).optional(),
+  })
+  .strict()
+
+export type AnswerPayload = z.infer<typeof AnswerPayloadSchema>
+
+/**
+ * Question payload - Agent asks for clarification
+ */
+export const QuestionPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    question: z.string().min(1),
+    options: z.array(z.string()).optional(),
+    blocking: z.boolean(),
+  })
+  .strict()
+
+export type QuestionPayload = z.infer<typeof QuestionPayloadSchema>
+
+/**
+ * Escalation option schema
+ */
+export const EscalationOptionSchema = z
+  .object({
+    label: z.string().min(1),
+    value: z.string().min(1),
+  })
+  .strict()
+
+export type EscalationOption = z.infer<typeof EscalationOptionSchema>
+
+/**
+ * Escalation payload - Agent escalates to Orca for a decision
+ */
+export const EscalationPayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema,
+    decision_id: z.string().min(1),
+    decision: z.string().min(1),
+    options: z.array(EscalationOptionSchema).min(1),
+    context: z.string(),
+  })
+  .strict()
+
+export type EscalationPayload = z.infer<typeof EscalationPayloadSchema>
+
+/**
+ * User input payload - User provides input
+ */
+export const UserInputPayloadSchema = z
+  .object({
+    content: z.string(),
+    in_response_to: SessionIdSchema.optional(),
+  })
+  .strict()
+
+export type UserInputPayload = z.infer<typeof UserInputPayloadSchema>
+
+/**
+ * Interrupt payload - User interrupts execution
+ */
+export const InterruptPayloadSchema = z
+  .object({
+    reason: z.string().min(1),
+    agent_id: AgentIdSchema.optional(),
+  })
+  .strict()
+
+export type InterruptPayload = z.infer<typeof InterruptPayloadSchema>
+
+/**
+ * Failure payload - Agent reports a failure
+ */
+export const FailurePayloadSchema = z
+  .object({
+    agent_id: AgentIdSchema.optional(),
+    code: ErrorCodeSchema,
+    message: z.string().min(1),
+    cause: z.string().optional(),
+  })
+  .strict()
+
+export type FailurePayload = z.infer<typeof FailurePayloadSchema>


### PR DESCRIPTION
Add Zod discriminated union schemas for 9 message types (task, result, plan, answer, question, escalation, user_input, interrupt, failure) with strict validation and exported TypeScript types.