### PR TITLE
feat: Zod 4 schema migration + agent tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or manually add to your `opencode.json`:
 ## Architecture
 
 ```
-User Input
+User Inputa
     │
     ▼
   Orca (Orchestrator)

--- a/src/plugin/agents.test.ts
+++ b/src/plugin/agents.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_AGENTS, PROTOCOL_INJECTION, mergeAgentConfigs } from './agents'
+import type { AgentConfig } from './config'
+
+describe('DEFAULT_AGENTS', () => {
+  test('contains all expected agents', () => {
+    const expectedAgents = [
+      'orca',
+      'strategist',
+      'coder',
+      'tester',
+      'reviewer',
+      'researcher',
+      'document-writer',
+      'architect',
+    ]
+    expect(Object.keys(DEFAULT_AGENTS).sort()).toEqual(expectedAgents.sort())
+  })
+
+  test('orca is the primary agent', () => {
+    expect(DEFAULT_AGENTS.orca.mode).toBe('primary')
+  })
+
+  test('all specialists are subagents', () => {
+    const specialists = Object.entries(DEFAULT_AGENTS).filter(([id]) => id !== 'orca')
+    for (const [id, config] of specialists) {
+      expect(config.mode).toBe('subagent')
+    }
+  })
+
+  test('all agents have valid hex colors', () => {
+    const hexColorRegex = /^#[0-9A-Fa-f]{6}$/
+    for (const [id, config] of Object.entries(DEFAULT_AGENTS)) {
+      expect(config.color).toMatch(hexColorRegex)
+    }
+  })
+
+  test('all agents have descriptions', () => {
+    for (const [id, config] of Object.entries(DEFAULT_AGENTS)) {
+      expect(config.description).toBeDefined()
+      expect(config.description?.length).toBeGreaterThan(10)
+    }
+  })
+
+  test('all agents have prompts with protocol injection', () => {
+    for (const [id, config] of Object.entries(DEFAULT_AGENTS)) {
+      expect(config.prompt).toBeDefined()
+      expect(config.prompt).toContain('Orca Communication Protocol')
+    }
+  })
+})
+
+describe('PROTOCOL_INJECTION', () => {
+  test('contains protocol header', () => {
+    expect(PROTOCOL_INJECTION).toContain('## Orca Communication Protocol')
+  })
+
+  test('documents all message types', () => {
+    const expectedTypes = [
+      'task',
+      'result',
+      'question',
+      'answer',
+      'failure',
+      'plan',
+      'escalation',
+      'interrupt',
+      'user_input',
+    ]
+    for (const type of expectedTypes) {
+      expect(PROTOCOL_INJECTION).toContain(`**${type}**`)
+    }
+  })
+
+  test('includes JSON schema in expandable section', () => {
+    expect(PROTOCOL_INJECTION).toContain('<details>')
+    expect(PROTOCOL_INJECTION).toContain('Full JSON Schema')
+    expect(PROTOCOL_INJECTION).toContain('</details>')
+  })
+})
+
+describe('mergeAgentConfigs', () => {
+  test('returns defaults when no user config provided', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default prompt' },
+    }
+    const result = mergeAgentConfigs(defaults)
+    expect(result).toEqual(defaults)
+  })
+
+  test('returns defaults when user config is empty', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default prompt' },
+    }
+    const result = mergeAgentConfigs(defaults, {})
+    expect(result).toEqual(defaults)
+  })
+
+  test('merges user overrides with defaults', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default prompt', color: '#000000' },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: { model: 'gpt-4o' },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    // User's model applied
+    expect(result.coder.model).toBe('gpt-4o')
+    // Defaults preserved
+    expect(result.coder.prompt).toBe('Default prompt')
+    expect(result.coder.color).toBe('#000000')
+    expect(result.coder.mode).toBe('subagent')
+  })
+
+  test('user values override defaults for same field', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default prompt' },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: { prompt: 'Custom prompt' },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+    expect(result.coder.prompt).toBe('Custom prompt')
+    expect(result.coder.mode).toBe('subagent')
+  })
+
+  test('excludes disabled agents', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Coder' },
+      tester: { mode: 'subagent', prompt: 'Tester' },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: { disable: true },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder).toBeUndefined()
+    expect(result.tester).toBeDefined()
+  })
+
+  test('adds new custom agents from user config', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Coder' },
+    }
+    const user: Record<string, AgentConfig> = {
+      'my-specialist': { mode: 'subagent', prompt: 'Custom specialist', color: '#FF0000' },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder).toBeDefined()
+    expect(result['my-specialist']).toBeDefined()
+    expect(result['my-specialist'].prompt).toBe('Custom specialist')
+  })
+
+  test('excludes disabled custom agents', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent' },
+    }
+    const user: Record<string, AgentConfig> = {
+      'my-specialist': { mode: 'subagent', disable: true },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder).toBeDefined()
+    expect(result['my-specialist']).toBeUndefined()
+  })
+
+  test('deep merges nested objects (tools)', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: {
+        mode: 'subagent',
+        tools: { read: true, edit: true, bash: false },
+      },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: {
+        tools: { bash: true, webfetch: true },
+      },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder.tools).toEqual({
+      read: true, // preserved from default
+      edit: true, // preserved from default
+      bash: true, // overridden by user
+      webfetch: true, // added by user
+    })
+  })
+
+  test('deep merges nested objects (permission)', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: {
+        mode: 'subagent',
+        permission: { edit: 'ask', bash: 'deny' },
+      },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: {
+        permission: { bash: 'allow' },
+      },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder.permission).toEqual({
+      edit: 'ask', // preserved from default
+      bash: 'allow', // overridden by user
+    })
+  })
+
+  test('preserves pass-through provider options during merge', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default' },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: {
+        model: 'openai/o1',
+        reasoningEffort: 'high', // pass-through option
+      } as AgentConfig,
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder.model).toBe('openai/o1')
+    expect((result.coder as Record<string, unknown>).reasoningEffort).toBe('high')
+    expect(result.coder.prompt).toBe('Default')
+  })
+
+  test('handles undefined values in user config gracefully', () => {
+    const defaults: Record<string, AgentConfig> = {
+      coder: { mode: 'subagent', prompt: 'Default', color: '#000000' },
+    }
+    const user: Record<string, AgentConfig> = {
+      coder: { model: 'gpt-4o', color: undefined },
+    }
+    const result = mergeAgentConfigs(defaults, user)
+
+    expect(result.coder.model).toBe('gpt-4o')
+    expect(result.coder.color).toBe('#000000') // undefined doesn't override
+  })
+})

--- a/src/plugin/config.test.ts
+++ b/src/plugin/config.test.ts
@@ -77,13 +77,18 @@ describe('config schemas', () => {
       expect(() => AgentConfigSchema.parse({ temperature: 3 })).toThrow()
     })
 
-    test('rejects extra fields (strict mode)', () => {
-      expect(() =>
-        AgentConfigSchema.parse({
-          model: 'test',
-          unknown_field: 'value',
-        }),
-      ).toThrow()
+    test('allows pass-through provider options (loose mode)', () => {
+      // AgentConfigSchema uses looseObject to allow provider-specific options
+      // like reasoningEffort, textVerbosity, etc. to pass through to the SDK
+      const config = {
+        model: 'openai/o1',
+        reasoningEffort: 'high',
+        customProviderOption: 'value',
+      }
+      const result = AgentConfigSchema.parse(config)
+      expect(result).toEqual(config)
+      expect(result.reasoningEffort).toBe('high')
+      expect(result.customProviderOption).toBe('value')
     })
   })
 

--- a/src/plugin/config.ts
+++ b/src/plugin/config.ts
@@ -15,20 +15,18 @@ export type AutonomyLevel = z.infer<typeof AutonomyLevelSchema>
 /**
  * Permission settings for agent actions
  */
-export const PermissionConfigSchema = z
-  .object({
-    edit: z.enum(['ask', 'allow', 'deny']).optional(),
-    bash: z
-      .union([
-        z.enum(['ask', 'allow', 'deny']),
-        z.record(z.string(), z.enum(['ask', 'allow', 'deny'])),
-      ])
-      .optional(),
-    webfetch: z.enum(['ask', 'allow', 'deny']).optional(),
-    doom_loop: z.enum(['ask', 'allow', 'deny']).optional(),
-    external_directory: z.enum(['ask', 'allow', 'deny']).optional(),
-  })
-  .strict()
+export const PermissionConfigSchema = z.strictObject({
+  edit: z.enum(['ask', 'allow', 'deny']).optional(),
+  bash: z
+    .union([
+      z.enum(['ask', 'allow', 'deny']),
+      z.record(z.string(), z.enum(['ask', 'allow', 'deny'])),
+    ])
+    .optional(),
+  webfetch: z.enum(['ask', 'allow', 'deny']).optional(),
+  doom_loop: z.enum(['ask', 'allow', 'deny']).optional(),
+  external_directory: z.enum(['ask', 'allow', 'deny']).optional(),
+})
 
 export type PermissionConfig = z.infer<typeof PermissionConfigSchema>
 
@@ -36,48 +34,43 @@ export type PermissionConfig = z.infer<typeof PermissionConfigSchema>
  * Agent configuration that can be provided by users
  * Matches OpenCode's AgentConfig structure
  */
-export const AgentConfigSchema = z
-  .object({
-    model: z.string().optional(),
-    temperature: z.number().min(0).max(2).optional(),
-    top_p: z.number().min(0).max(1).optional(),
-    prompt: z.string().optional(),
-    tools: z.record(z.string(), z.boolean()).optional(),
-    disable: z.boolean().optional(),
-    description: z.string().optional(),
-    mode: z.enum(['subagent', 'primary', 'all']).optional(),
-    color: z
-      .string()
-      .regex(/^#[0-9A-Fa-f]{6}$/)
-      .optional(),
-    maxSteps: z.number().int().positive().optional(),
-    permission: PermissionConfigSchema.optional(),
-  })
-  .strict()
+export const AgentConfigSchema = z.looseObject({
+  model: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  top_p: z.number().min(0).max(1).optional(),
+  prompt: z.string().optional(),
+  tools: z.record(z.string(), z.boolean()).optional(),
+  disable: z.boolean().optional(),
+  description: z.string().optional(),
+  mode: z.enum(['subagent', 'primary', 'all']).optional(),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/)
+    .optional(),
+  maxSteps: z.number().int().positive().optional(),
+  permission: PermissionConfigSchema.optional(),
+})
 
 export type AgentConfig = z.infer<typeof AgentConfigSchema>
 
 /**
  * Orca-specific settings
  */
-export const OrcaSettingsSchema = z
-  .object({
-    /** Default autonomy level for all agents */
-    autonomy: AutonomyLevelSchema.optional(),
-    /** Default model for agents that don't specify one */
-    defaultModel: z.string().optional(),
-    /** Validation settings */
-    validation: z
-      .object({
-        /** Max retries for message validation failures (default: 3) */
-        maxRetries: z.number().int().min(0).max(10).optional(),
-        /** Wrap plain text responses in result messages (default: true) */
-        wrapPlainText: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
+export const OrcaSettingsSchema = z.strictObject({
+  /** Default autonomy level for all agents */
+  autonomy: AutonomyLevelSchema.optional(),
+  /** Default model for agents that don't specify one */
+  defaultModel: z.string().optional(),
+  /** Validation settings */
+  validation: z
+    .strictObject({
+      /** Max retries for message validation failures (default: 3) */
+      maxRetries: z.number().int().min(0).max(10).optional(),
+      /** Wrap plain text responses in result messages (default: true) */
+      wrapPlainText: z.boolean().optional(),
+    })
+    .optional(),
+})
 
 export type OrcaSettings = z.infer<typeof OrcaSettingsSchema>
 
@@ -89,14 +82,12 @@ export type OrcaSettings = z.infer<typeof OrcaSettingsSchema>
  * - Adding completely new custom agents (full configs)
  * - Global Orca settings (autonomy level, default model)
  */
-export const OrcaUserConfigSchema = z
-  .object({
-    /** Agent configurations - overrides or new agents */
-    agents: z.record(z.string(), AgentConfigSchema).optional(),
-    /** Global Orca settings */
-    settings: OrcaSettingsSchema.optional(),
-  })
-  .strict()
+export const OrcaUserConfigSchema = z.strictObject({
+  /** Agent configurations - overrides or new agents */
+  agents: z.record(z.string(), AgentConfigSchema).optional(),
+  /** Global Orca settings */
+  settings: OrcaSettingsSchema.optional(),
+})
 
 export type OrcaUserConfig = z.infer<typeof OrcaUserConfigSchema>
 

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -21,11 +21,9 @@ export type AgentId = z.infer<typeof AgentIdSchema>
 /**
  * Base envelope fields shared by all messages
  */
-export const BaseEnvelopeSchema = z
-  .object({
-    session_id: SessionIdSchema,
-    timestamp: TimestampSchema,
-  })
-  .strict()
+export const BaseEnvelopeSchema = z.strictObject({
+  session_id: SessionIdSchema,
+  timestamp: TimestampSchema,
+})
 
 export type BaseEnvelope = z.infer<typeof BaseEnvelopeSchema>

--- a/src/schemas/messages.ts
+++ b/src/schemas/messages.ts
@@ -18,7 +18,7 @@ import {
 export const TaskMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('task'),
   payload: TaskPayloadSchema,
-}).strict()
+})
 
 export type TaskMessage = z.infer<typeof TaskMessageSchema>
 
@@ -28,7 +28,7 @@ export type TaskMessage = z.infer<typeof TaskMessageSchema>
 export const ResultMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('result'),
   payload: ResultPayloadSchema,
-}).strict()
+})
 
 export type ResultMessage = z.infer<typeof ResultMessageSchema>
 
@@ -38,7 +38,7 @@ export type ResultMessage = z.infer<typeof ResultMessageSchema>
 export const PlanMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('plan'),
   payload: PlanPayloadSchema,
-}).strict()
+})
 
 export type PlanMessage = z.infer<typeof PlanMessageSchema>
 
@@ -48,7 +48,7 @@ export type PlanMessage = z.infer<typeof PlanMessageSchema>
 export const AnswerMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('answer'),
   payload: AnswerPayloadSchema,
-}).strict()
+})
 
 export type AnswerMessage = z.infer<typeof AnswerMessageSchema>
 
@@ -58,7 +58,7 @@ export type AnswerMessage = z.infer<typeof AnswerMessageSchema>
 export const QuestionMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('question'),
   payload: QuestionPayloadSchema,
-}).strict()
+})
 
 export type QuestionMessage = z.infer<typeof QuestionMessageSchema>
 
@@ -68,7 +68,7 @@ export type QuestionMessage = z.infer<typeof QuestionMessageSchema>
 export const EscalationMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('escalation'),
   payload: EscalationPayloadSchema,
-}).strict()
+})
 
 export type EscalationMessage = z.infer<typeof EscalationMessageSchema>
 
@@ -78,7 +78,7 @@ export type EscalationMessage = z.infer<typeof EscalationMessageSchema>
 export const UserInputMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('user_input'),
   payload: UserInputPayloadSchema,
-}).strict()
+})
 
 export type UserInputMessage = z.infer<typeof UserInputMessageSchema>
 
@@ -88,7 +88,7 @@ export type UserInputMessage = z.infer<typeof UserInputMessageSchema>
 export const InterruptMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('interrupt'),
   payload: InterruptPayloadSchema,
-}).strict()
+})
 
 export type InterruptMessage = z.infer<typeof InterruptMessageSchema>
 
@@ -98,7 +98,7 @@ export type InterruptMessage = z.infer<typeof InterruptMessageSchema>
 export const FailureMessageSchema = BaseEnvelopeSchema.extend({
   type: z.literal('failure'),
   payload: FailurePayloadSchema,
-}).strict()
+})
 
 export type FailureMessage = z.infer<typeof FailureMessageSchema>
 

--- a/src/schemas/payloads.ts
+++ b/src/schemas/payloads.ts
@@ -5,145 +5,123 @@ import { ErrorCodeSchema } from './errors'
 /**
  * Task payload - Orca assigns work to a specialist agent
  */
-export const TaskPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    prompt: z.string().min(1),
-    context: z.record(z.string(), z.unknown()).optional(),
-    parent_session_id: SessionIdSchema.optional(),
-  })
-  .strict()
+export const TaskPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  prompt: z.string().min(1),
+  context: z.record(z.string(), z.unknown()).optional(),
+  parent_session_id: SessionIdSchema.optional(),
+})
 
 export type TaskPayload = z.infer<typeof TaskPayloadSchema>
 
 /**
  * Result payload - Specialist returns completed work
  */
-export const ResultPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    content: z.string(),
-    artifacts: z.array(z.string()).optional(),
-  })
-  .strict()
+export const ResultPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  content: z.string(),
+  artifacts: z.array(z.string()).optional(),
+})
 
 export type ResultPayload = z.infer<typeof ResultPayloadSchema>
 
 /**
  * Plan step schema
  */
-export const PlanStepSchema = z
-  .object({
-    description: z.string().min(1),
-    command: z.string().optional(),
-  })
-  .strict()
+export const PlanStepSchema = z.strictObject({
+  description: z.string().min(1),
+  command: z.string().optional(),
+})
 
 export type PlanStep = z.infer<typeof PlanStepSchema>
 
 /**
  * Plan payload - Strategist returns an execution plan
  */
-export const PlanPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    goal: z.string().min(1),
-    steps: z.array(PlanStepSchema).min(1),
-    assumptions: z.array(z.string()).optional(),
-    files_touched: z.array(z.string()).optional(),
-  })
-  .strict()
+export const PlanPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  goal: z.string().min(1),
+  steps: z.array(PlanStepSchema).min(1),
+  assumptions: z.array(z.string()).optional(),
+  files_touched: z.array(z.string()).optional(),
+})
 
 export type PlanPayload = z.infer<typeof PlanPayloadSchema>
 
 /**
  * Answer payload - Response to a question
  */
-export const AnswerPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    content: z.string(),
-    sources: z.array(z.string()).optional(),
-  })
-  .strict()
+export const AnswerPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  content: z.string(),
+  sources: z.array(z.string()).optional(),
+})
 
 export type AnswerPayload = z.infer<typeof AnswerPayloadSchema>
 
 /**
  * Question payload - Agent asks for clarification
  */
-export const QuestionPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    question: z.string().min(1),
-    options: z.array(z.string()).optional(),
-    blocking: z.boolean(),
-  })
-  .strict()
+export const QuestionPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  question: z.string().min(1),
+  options: z.array(z.string()).optional(),
+  blocking: z.boolean(),
+})
 
 export type QuestionPayload = z.infer<typeof QuestionPayloadSchema>
 
 /**
  * Escalation option schema
  */
-export const EscalationOptionSchema = z
-  .object({
-    label: z.string().min(1),
-    value: z.string().min(1),
-  })
-  .strict()
+export const EscalationOptionSchema = z.strictObject({
+  label: z.string().min(1),
+  value: z.string().min(1),
+})
 
 export type EscalationOption = z.infer<typeof EscalationOptionSchema>
 
 /**
  * Escalation payload - Agent escalates to Orca for a decision
  */
-export const EscalationPayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema,
-    decision_id: z.string().min(1),
-    decision: z.string().min(1),
-    options: z.array(EscalationOptionSchema).min(1),
-    context: z.string(),
-  })
-  .strict()
+export const EscalationPayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema,
+  decision_id: z.string().min(1),
+  decision: z.string().min(1),
+  options: z.array(EscalationOptionSchema).min(1),
+  context: z.string(),
+})
 
 export type EscalationPayload = z.infer<typeof EscalationPayloadSchema>
 
 /**
  * User input payload - User provides input
  */
-export const UserInputPayloadSchema = z
-  .object({
-    content: z.string(),
-    in_response_to: SessionIdSchema.optional(),
-  })
-  .strict()
+export const UserInputPayloadSchema = z.strictObject({
+  content: z.string(),
+  in_response_to: SessionIdSchema.optional(),
+})
 
 export type UserInputPayload = z.infer<typeof UserInputPayloadSchema>
 
 /**
  * Interrupt payload - User interrupts execution
  */
-export const InterruptPayloadSchema = z
-  .object({
-    reason: z.string().min(1),
-    agent_id: AgentIdSchema.optional(),
-  })
-  .strict()
+export const InterruptPayloadSchema = z.strictObject({
+  reason: z.string().min(1),
+  agent_id: AgentIdSchema.optional(),
+})
 
 export type InterruptPayload = z.infer<typeof InterruptPayloadSchema>
 
 /**
  * Failure payload - Agent reports a failure
  */
-export const FailurePayloadSchema = z
-  .object({
-    agent_id: AgentIdSchema.optional(),
-    code: ErrorCodeSchema,
-    message: z.string().min(1),
-    cause: z.string().optional(),
-  })
-  .strict()
+export const FailurePayloadSchema = z.strictObject({
+  agent_id: AgentIdSchema.optional(),
+  code: ErrorCodeSchema,
+  message: z.string().min(1),
+  cause: z.string().optional(),
+})
 
 export type FailurePayload = z.infer<typeof FailurePayloadSchema>


### PR DESCRIPTION
## Summary
- Migrates schemas to Zod 4 idioms (z.strictObject, z.looseObject) and removes redundant .strict() from extended message schemas.
- Allows provider-specific pass-through options in AgentConfigSchema (e.g. reasoningEffort).
- Adds comprehensive agent tests and updates config tests for pass-through behavior.

## Related
- Closes #11