### PR TITLE
docs: add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# opencode-orca &#x1FACD;
+# opencode-orca 🪼
 
 OpenCode plugin for safe and effective agent orchestration.
 
-## Overview
+## Requirements
 
-This plugin provides a structured agent orchestration system with:
+- [OpenCode](https://opencode.ai) ^1.0.0
+- [Bun](https://bun.sh) runtime
 
-- **Type-enforced contracts** via Zod discriminated union validation
-- **State machine orchestration** (IDLE/EXECUTING) with human-in-the-loop gates
-- **Session continuity** between agents via session_id tracking
-- **Per-agent supervision** with checkpoint protocol for approval gates
+## Features
+
+- **Type-enforced contracts** - Zod discriminated union validation for all agent messages
+- **State machine orchestration** - IDLE/EXECUTING states with human-in-the-loop gates
+- **Session continuity** - Persistent context between agents via session_id tracking
+- **Per-agent supervision** - Checkpoint protocol for approval gates on sensitive operations
 
 ## Architecture
 
@@ -30,28 +33,13 @@ User Input
          └── Architect
 ```
 
-
 ## Installation
-
-The easiest way to install is using the CLI:
 
 ```bash
 bunx @ex-machina/opencode-orca@latest install
 ```
 
-This will:
-1. Add `@ex-machina/opencode-orca` to the `plugin` array in your `opencode.jsonc`
-2. Create a default configuration file at `.opencode/orca.json`
-
-### Manual Installation
-
-Alternatively, add to your `opencode.jsonc` manually:
-
-```json
-{
-  "plugin": ["@ex-machina/opencode-orca"]
-}
-```
+See [Getting Started](docs/getting-started.md) for verification steps and first use.
 
 ## Configuration
 
@@ -66,68 +54,21 @@ Create `.opencode/orca.json` to customize behavior:
   "agents": {
     "coder": {
       "supervised": true
-    },
-    "my-specialist": {
-      "mode": "subagent",
-      "description": "Custom specialist agent",
-      "prompt": "You are a custom specialist..."
     }
   }
 }
 ```
 
-### Supervision
+See [Configuration](docs/configuration.md) for the full reference.
 
-Agents can be marked as "supervised" to require user approval before dispatch:
+## Documentation
 
-- **Per-agent**: Set `supervised: true` on specific agents
-- **Global default**: Set `settings.defaultSupervised: true` for all agents
-
-When dispatching to a supervised agent, the plugin returns a `checkpoint` message instead of executing. The orchestrator (Orca) presents this to the user for approval before proceeding.
-
-## CLI Commands
-
-### `opencode-orca install`
-
-Installs the Orca plugin into your OpenCode project.
-
-```bash
-bunx @ex-machina/opencode-orca install [options]
-
-Options:
-  --force, -f    Force reinstall even if already installed
-```
-
-### `opencode-orca uninstall`
-
-Removes the Orca plugin from your OpenCode project.
-
-```bash
-bunx @ex-machina/opencode-orca uninstall [options]
-
-Options:
-  --remove-config, -r    Remove .opencode/orca.json without prompting
-  --keep-config, -k      Keep .opencode/orca.json without prompting
-```
-
-### `opencode-orca init`
-
-Creates only the `.opencode/orca.json` configuration file without modifying `opencode.jsonc`. Useful for customizing the config before installing.
-
-```bash
-bunx @ex-machina/opencode-orca init [options]
-
-Options:
-  --force, -f    Overwrite existing configuration
-```
-
-### `opencode-orca --help`
-
-Shows help information.
-
-### `opencode-orca --version`
-
-Shows the installed version.
+- [Getting Started](docs/getting-started.md) - Quick start guide
+- [Configuration](docs/configuration.md) - Full orca.json reference
+- [Architecture](docs/architecture.md) - System design and decisions
+- [Custom Agents](docs/custom-agents.md) - Creating custom agents
+- [Supervision](docs/supervision.md) - Checkpoint and HITL model
+- [Troubleshooting](docs/troubleshooting.md) - Common issues
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# opencode-orca Documentation
+
+OpenCode plugin for safe agent orchestration with human-in-the-loop supervision.
+
+## What is opencode-orca?
+
+A plugin that adds multi-agent orchestration to OpenCode with:
+
+- **Supervised execution** - Checkpoint-based approval gates before agent actions
+- **Built-in specialists** - Coder, Tester, Reviewer, Researcher, Document Writer, Architect
+- **Custom agents** - Define project-specific agents via `orca.json`
+- **Session continuity** - State tracking across agent handoffs
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](getting-started.md) | Installation, first run, basic usage |
+| [Configuration](configuration.md) | `orca.json` schema and options reference |
+| [Architecture](architecture.md) | System design, message flow, state machine |
+| [Custom Agents](custom-agents.md) | Defining and configuring custom specialists |
+| [Supervision](supervision.md) | Checkpoint protocol and HITL approval model |
+| [Troubleshooting](troubleshooting.md) | Common issues and solutions |
+
+## Quick Navigation
+
+**I want to...**
+
+- **Install the plugin** - See [Getting Started](getting-started.md)
+- **Configure agent behavior** - See [Configuration](configuration.md)
+- **Add a custom agent** - See [Custom Agents](custom-agents.md)
+- **Require approval for agents** - See [Supervision](supervision.md)
+- **Understand how it works** - See [Architecture](architecture.md)
+- **Fix an error** - See [Troubleshooting](troubleshooting.md)
+
+## Quick Install
+
+```bash
+bunx @ex-machina/opencode-orca@latest install
+```
+
+See [Getting Started](getting-started.md) for details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,127 @@
+# Architecture
+
+This document describes the system design and architecture decisions behind opencode-orca.
+
+## High-Level Architecture
+
+```
+                              +-------------------+
+                              |    User Input     |
+                              +--------+----------+
+                                       |
+                                       v
+                    +------------------+------------------+
+                    |           Orca (Orchestrator)       |
+                    |           mode: 'primary'           |
+                    +------------------+------------------+
+                                       |
+            +-----------+--------------+--------------+-----------+
+            |           |              |              |           |
+            v           v              v              v           v
+     +------+----+ +----+-----+ +-----+----+ +------+-----+ +-----+------+
+     | Strategist| |  Coder   | |  Tester  | | Researcher | |  Reviewer  |
+     |  (plans)  | | (code)   | | (tests)  | |  (search)  | | (quality)  |
+     +-----------+ +----------+ +----------+ +------------+ +------------+
+                          |                         |
+                          v                         v
+                   +------+------+          +------+-------+
+                   | Doc Writer  |          |  Architect   |
+                   |   (docs)    |          |  (design)    |
+                   +-------------+          +--------------+
+```
+
+## Agent Hierarchy
+
+**Orca (Orchestrator)** - Mode: `primary`. Receives all user messages, routes to specialists, synthesizes results. Uses strategist for 3+ step tasks.
+
+**Strategist** - Mode: `subagent`. Plans complex multi-step tasks before execution. Outputs structured plans with goals, steps, assumptions.
+
+**Specialists** - All `subagent` mode, invoked by Orca:
+
+| Agent | Purpose |
+|-------|---------|
+| coder | Implements code changes, features, fixes |
+| tester | Writes and runs tests |
+| reviewer | Reviews code for issues and improvements |
+| researcher | Investigates codebases, APIs, documentation |
+| document-writer | Creates technical documentation |
+| architect | Advises on system design decisions |
+
+## Message Protocol
+
+All inter-agent communication uses typed message envelopes validated by Zod discriminated unions.
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `task` | Orca -> Agent | Assigns work to a specialist |
+| `plan` | Strategist -> Orca | Returns execution plan |
+| `answer` | Agent -> Orca | Response with content, sources, annotations |
+| `question` | Agent -> Orca | Asks for clarification |
+| `escalation` | Agent -> Orca | Escalates decision to orchestrator |
+| `user_input` | User -> Orca | User provides input |
+| `interrupt` | User -> Orca | User interrupts execution |
+| `failure` | Agent -> Orca | Reports error with code |
+| `checkpoint` | System -> Orca | Requires user approval |
+
+### Envelope Structure
+
+Request messages (task, user_input, interrupt):
+```typescript
+{ type, session_id: UUID, timestamp: ISO8601, payload }
+```
+
+Response messages (answer, plan, question, escalation, failure, checkpoint):
+```typescript
+{ type, timestamp: ISO8601, payload }
+```
+
+Response messages omit `session_id` - Orca manages sessions externally.
+
+## Session Continuity
+
+Sessions maintain context across agent handoffs:
+
+- **session_id**: UUID identifying the conversation session
+- **parent_session_id**: Links child tasks to parent session for context
+- **plan_context**: Tracks plan execution state (goal, step_index, approved_remaining)
+
+```
+User Request -> Orca creates session -> Dispatches task with parent_session_id
+             -> Agent responds in same context -> Orca synthesizes and continues
+```
+
+## State Machine
+
+```
+          +--------+                    +------------+
+          |  IDLE  |  <-- checkpoint    | EXECUTING  |
+          |        |      approval -->  |            |
+          +---+----+                    +-----+------+
+              |                               |
+              | user_input                    | task dispatch
+              v                               v
+         [Route to Orca]              [Agent processing]
+```
+
+- **IDLE**: Waiting for user input or checkpoint approval
+- **EXECUTING**: Processing task through agent pipeline
+- Checkpoint pauses execution until user approves
+- Completion returns to IDLE state
+
+## Design Decisions
+
+### Zod Discriminated Unions for Validation
+
+Type-safe message handling with runtime validation. Compile-time type inference from schemas, runtime validation catches malformed messages early, single source of truth for message structure, discriminant field enables exhaustive switch handling.
+
+### Checkpoint Protocol for Supervision
+
+Human-in-the-loop safety for sensitive operations. Supervised agents require explicit approval before execution. Users can approve individual steps or "approve all remaining" via `plan_context.approved_remaining`.
+
+### Session-Based Context Passing
+
+Maintains conversation state across agent handoffs. Agents see relevant history from parent session. Parent-child linking preserves execution trace for coherent multi-step task completion.
+
+### Response Validation with Retry
+
+Ensures agents respond in correct format. Validates all agent responses against expected schemas. On validation failure, re-prompts agent with correction guidance. Configurable retry count prevents infinite loops.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,150 @@
+# Configuration Reference
+
+Configure opencode-orca via `.opencode/orca.json` in your project root.
+
+## File Structure
+
+```json
+{
+  "settings": { ... },
+  "agents": { ... }
+}
+```
+
+Both top-level keys are optional. The file itself is optional.
+
+## Settings
+
+Global plugin settings under the `settings` key.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `defaultSupervised` | boolean | `false` | Require user approval for all agents by default |
+| `defaultModel` | string | - | Default model for agents without explicit model config |
+| `updateNotifier` | boolean | `true` | Show notifications about plugin updates |
+| `validation.maxRetries` | number (0-10) | `3` | Max retries when agent response fails validation |
+| `validation.wrapPlainText` | boolean | `true` | Wrap plain text responses in result messages |
+
+## Agent Configuration
+
+Override built-in agents or define custom ones under the `agents` key.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `model` | string | Model identifier (e.g., `claude-sonnet-4-20250514`) |
+| `temperature` | number (0-2) | Sampling temperature |
+| `top_p` | number (0-1) | Nucleus sampling parameter |
+| `prompt` | string | System prompt (overrides built-in prompt) |
+| `tools` | `Record<string, boolean>` | Enable/disable specific tools |
+| `disable` | boolean | Disable this agent entirely |
+| `description` | string | Agent description shown in UI |
+| `mode` | `'subagent'` \| `'primary'` \| `'all'` | Agent visibility mode |
+| `color` | string | Hex color for UI display (`#RRGGBB`) |
+| `maxSteps` | number | Maximum steps before agent stops |
+| `permission` | PermissionConfig | Permission overrides (see below) |
+| `supervised` | boolean | Require user approval before dispatch |
+| `responseTypes` | array | Allowed response types (see below) |
+
+### Response Types
+
+Allowed message types: `answer`, `plan`, `question`, `escalation`, `failure`. Default: `['answer', 'failure']`
+
+### Permission Config
+
+Fine-grained permission control per agent.
+
+| Permission | Type | Description |
+|------------|------|-------------|
+| `edit` | `'ask'` \| `'allow'` \| `'deny'` | File editing permission |
+| `bash` | enum or `Record<pattern, enum>` | Shell command permission |
+| `webfetch` | `'ask'` \| `'allow'` \| `'deny'` | Web fetch permission |
+| `doom_loop` | `'ask'` \| `'allow'` \| `'deny'` | Allow repeated failures |
+| `external_directory` | `'ask'` \| `'allow'` \| `'deny'` | Access outside project |
+
+For `bash`, you can specify per-command patterns:
+
+```json
+{
+  "bash": {
+    "git *": "allow",
+    "rm *": "deny",
+    "*": "ask"
+  }
+}
+```
+
+## Examples
+
+### Enable Supervision Globally
+
+Require approval before any agent executes:
+
+```json
+{
+  "settings": {
+    "defaultSupervised": true
+  }
+}
+```
+
+### Override a Built-in Agent
+
+Change the coder agent's model and temperature:
+
+```json
+{
+  "agents": {
+    "coder": {
+      "model": "claude-sonnet-4-20250514",
+      "temperature": 0.3,
+      "maxSteps": 50
+    }
+  }
+}
+```
+
+### Add a Custom Agent
+
+Define a project-specific specialist:
+
+```json
+{
+  "agents": {
+    "api-designer": {
+      "description": "Designs REST API endpoints",
+      "model": "claude-sonnet-4-20250514",
+      "mode": "subagent",
+      "prompt": "You are an API design specialist...",
+      "responseTypes": ["answer", "question", "failure"],
+      "supervised": true,
+      "permission": {
+        "edit": "allow",
+        "bash": "deny"
+      }
+    }
+  }
+}
+```
+
+### Customize Validation and Notifications
+
+```json
+{
+  "settings": {
+    "updateNotifier": false,
+    "validation": {
+      "maxRetries": 1,
+      "wrapPlainText": false
+    }
+  }
+}
+```
+
+## Validation
+
+The plugin validates `orca.json` on load. Invalid configs produce clear error messages with paths and expected types. Fix all validation errors before the plugin will load.
+
+## See Also
+
+- [Custom Agents](custom-agents.md) - Detailed guide on creating agents
+- [Supervision](supervision.md) - How approval checkpoints work

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -1,0 +1,123 @@
+# Custom Agents
+
+Create specialized agents tailored to your project needs.
+
+## How Custom Agents Work
+
+Custom agents are defined in `.opencode/orca.json` under the `agents` key. Configurations merge with defaults, allowing you to override built-in agents (same name) or add new ones (unique name).
+
+Built-in agents: `orca`, `strategist`, `coder`, `tester`, `reviewer`, `researcher`, `document-writer`, `architect`
+
+## Configuration Fields
+
+For overrides, all fields are optional (they merge). For new agents, include:
+
+| Field | Purpose |
+|-------|---------|
+| `mode` | Set to `'subagent'` for agents dispatched by Orca |
+| `description` | Shown in UI; helps Orca select the right agent |
+| `prompt` | System prompt defining agent behavior |
+| `responseTypes` | Message types the agent can return |
+
+See [Configuration Reference](configuration.md) for all fields.
+
+## Protocol Requirements
+
+Agents respond with a JSON message envelope:
+
+```json
+{ "type": "answer", "timestamp": "2025-01-05T10:30:00Z", "payload": { ... } }
+```
+
+The `responseTypes` array determines valid message types. Default for subagents: `['answer', 'failure']`
+
+## Response Types
+
+| Type | Purpose | Key Payload Fields |
+|------|---------|-------------------|
+| `answer` | Content response | `agent_id`, `content`, `sources?`, `annotations?` |
+| `plan` | Execution plan | `agent_id`, `goal`, `steps[]` |
+| `question` | Ask clarification | `agent_id`, `question`, `options?`, `blocking` |
+| `escalation` | Escalate decision | `agent_id`, `decision_id`, `decision`, `options[]`, `context` |
+| `failure` | Report error | `agent_id?`, `code`, `message`, `cause?` |
+
+Error codes: `VALIDATION_ERROR`, `UNKNOWN_AGENT`, `SESSION_NOT_FOUND`, `AGENT_ERROR`, `TIMEOUT`
+
+### Example: Answer Response
+
+```json
+{
+  "type": "answer",
+  "payload": {
+    "agent_id": "security-reviewer",
+    "content": "Found 2 potential vulnerabilities...",
+    "sources": [{ "type": "file", "ref": "src/auth.ts" }]
+  }
+}
+```
+
+### Example: Question Response
+
+```json
+{
+  "type": "question",
+  "payload": {
+    "agent_id": "security-reviewer",
+    "question": "Which auth method should I evaluate?",
+    "options": ["OAuth2", "JWT", "Session-based"],
+    "blocking": true
+  }
+}
+```
+
+## Complete Example: Security Reviewer
+
+```json
+{
+  "agents": {
+    "security-reviewer": {
+      "description": "Reviews code for security vulnerabilities",
+      "mode": "subagent",
+      "model": "claude-sonnet-4-20250514",
+      "supervised": true,
+      "responseTypes": ["answer", "question", "failure"],
+      "prompt": "You are a security specialist. Analyze code for vulnerabilities including injection attacks, authentication flaws, and data exposure. Cite file locations. Ask questions if scope is unclear.",
+      "permission": { "edit": "deny", "bash": "deny" }
+    }
+  }
+}
+```
+
+Use it: `@orca Review the auth module for security issues`
+
+## Overriding Built-in Agents
+
+Use the same name; only specify fields to change:
+
+```json
+{
+  "agents": {
+    "coder": {
+      "supervised": true,
+      "model": "claude-sonnet-4-20250514",
+      "maxSteps": 30
+    }
+  }
+}
+```
+
+This adds supervision to coder while keeping its default prompt and tools.
+
+## Testing Custom Agents
+
+1. Verify config loads without errors (check OpenCode startup)
+2. Dispatch to your agent via `@orca` with a relevant task
+3. Confirm responses match your `responseTypes` list
+4. Check supervision gates appear if `supervised: true`
+
+Failed validations retry up to `validation.maxRetries` times before returning failure.
+
+## See Also
+
+- [Configuration Reference](configuration.md) - All configuration options
+- [Supervision](supervision.md) - Approval checkpoints

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,71 @@
+# Getting Started
+
+Get up and running with opencode-orca in under 30 seconds.
+
+## Prerequisites
+
+- [OpenCode](https://opencode.ai) ^1.0.0
+- [Bun](https://bun.sh) runtime
+
+## Quick Start
+
+### 1. Install the plugin
+
+Run this command in your project directory:
+
+```bash
+bunx @ex-machina/opencode-orca@latest install
+```
+
+This command:
+- Adds `@ex-machina/opencode-orca` to the `plugin` array in your `opencode.jsonc`
+- Creates a default configuration file at `.opencode/orca.json`
+
+### 2. Verify installation
+
+Check that the plugin was added to your OpenCode config:
+
+```bash
+cat opencode.jsonc
+```
+
+You should see:
+
+```json
+{
+  "plugin": ["@ex-machina/opencode-orca"]
+}
+```
+
+### 3. Start OpenCode
+
+Launch OpenCode in your project:
+
+```bash
+opencode
+```
+
+### 4. Talk to Orca
+
+In the OpenCode chat, try:
+
+```
+@orca Help me refactor the authentication module
+```
+
+Orca will analyze your request, create a plan, and coordinate specialist agents to execute it.
+
+## What happens next
+
+When you interact with Orca:
+
+1. **Strategist** analyzes your request and creates an execution plan
+2. **You approve** the plan (or request changes)
+3. **Specialist agents** execute each step (coder, tester, reviewer, etc.)
+4. **Orca** coordinates the workflow and reports results
+
+## Next steps
+
+- [Configuration](./configuration.md) - Customize models, validation, and agent behavior
+- [Custom Agents](./custom-agents.md) - Create your own specialist agents
+- [Supervision](./supervision.md) - Configure approval gates for agent actions

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -1,0 +1,126 @@
+# Supervision
+
+Supervision provides human-in-the-loop approval gates that prevent agents from executing tasks without explicit user consent. This safety mechanism protects against unintended destructive operations or external side effects.
+
+## How It Works
+
+When an agent is supervised, Orca cannot dispatch tasks directly. Instead, the plugin returns a **checkpoint** message that pauses execution and asks the user to approve before proceeding.
+
+```
+    Orca                  Plugin                  Agent
+      |                     |                      |
+      |--- dispatch task -->|                      |
+      |                     |-- check supervised --|
+      |<-- checkpoint ------|                      |
+      |                     |                      |
+   [User approves]          |                      |
+      |                     |                      |
+      |--- re-dispatch ---->|                      |
+      |  (approved: true)   |--- execute task ---->|
+      |                     |<---- response -------|
+      |<--- response -------|                      |
+```
+
+## Enabling Supervision
+
+### Per-Agent
+
+Set `supervised: true` on specific agents:
+
+```json
+{
+  "agents": {
+    "coder": {
+      "supervised": true
+    }
+  }
+}
+```
+
+### Globally
+
+Enable supervision for all agents by default:
+
+```json
+{
+  "settings": {
+    "defaultSupervised": true
+  }
+}
+```
+
+### Resolution Order
+
+1. Agent's explicit `supervised` setting (if defined)
+2. Global `defaultSupervised` setting (if defined)
+3. Default: `false` (no supervision)
+
+Per-agent settings always take precedence over global defaults.
+
+## Checkpoint Flow
+
+1. **Orca dispatches task** to a specialist agent via `orca_dispatch`
+2. **Plugin checks supervision** using `isAgentSupervised()` in dispatch.ts
+3. **If supervised and not pre-approved**, plugin returns a `checkpoint` message
+4. **Orca presents checkpoint** to the user, explaining what will run and why
+5. **User responds** with one of:
+   - Approve this step
+   - Deny this step
+   - Approve all remaining steps in this plan
+6. **If approved**, Orca re-dispatches with `plan_context.approved_remaining: true`
+7. **Agent executes** and returns its response
+
+## Plan Context
+
+The `plan_context` field in task messages tracks approval state across multi-step plans.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `goal` | string | The overall plan objective |
+| `step_index` | number | Current step number (0-based) |
+| `approved_remaining` | boolean | If true, skip checkpoints for remaining steps |
+
+When `approved_remaining` is true, subsequent supervised agents in the same plan execute without additional checkpoints.
+
+## Checkpoint Message Structure
+
+When a checkpoint is returned, it contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | The agent awaiting approval |
+| `prompt` | string | What the agent would execute |
+| `step_index` | number (optional) | Current step in the plan |
+| `plan_goal` | string (optional) | Overall objective of the plan |
+
+## When to Use Supervision
+
+Enable supervision for agents that perform potentially risky operations:
+
+| Use Case | Risk Level | Recommendation |
+|----------|------------|----------------|
+| File modifications (coder) | High | Supervise |
+| Shell command execution | High | Supervise |
+| External API calls | Medium | Consider supervising |
+| Code review (read-only) | Low | Usually not needed |
+| Research (read-only) | Low | Usually not needed |
+
+## Example Configuration
+
+Supervise high-risk agents while allowing read-only agents to run freely:
+
+```json
+{
+  "agents": {
+    "coder": { "supervised": true },
+    "tester": { "supervised": true },
+    "reviewer": { "supervised": false },
+    "researcher": { "supervised": false }
+  }
+}
+```
+
+## See Also
+
+- [Configuration](configuration.md) - Full configuration reference
+- [Custom Agents](custom-agents.md) - Creating supervised custom agents

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+Common issues and solutions for the opencode-orca plugin.
+
+## Installation Issues
+
+**Plugin not found**: Verify `opencode.jsonc` includes `"@ex-machina/opencode-orca"` in the `plugin` array.
+
+**orca.json invalid**: JSON syntax error. Common issues: trailing commas, missing quotes. Validate with `jq . .opencode/orca.json`.
+
+**Permission denied**: Check file permissions: `chmod 755 .opencode && chmod 644 .opencode/orca.json`
+
+## Configuration Issues
+
+**Schema validation errors**: Zod provides detailed paths. Example:
+```
+Invalid .opencode/orca.json:
+  - agents.researcher.temperature: Number must be less than or equal to 2
+```
+Each line shows `path: message`. Fix the value at the specified path.
+
+**Unknown fields rejected**: Root config uses `strictObject` - only `agents` and `settings` are valid. Remove unrecognized fields.
+
+**Type mismatches**: Common errors include `"0.7"` instead of `0.7` (temperature), `"true"` instead of `true` (disable), and invalid enums like `"sub-agent"` instead of `"subagent"`.
+
+## Runtime Issues
+
+**Agent not responding**: Check for `disable: true` in config. Verify model exists and you have quota.
+
+**Validation failures**: If responses fail format validation, increase `settings.validation.maxRetries` (default: 3, max: 10) or enable `wrapPlainText: true`.
+
+**Agent returns wrong format**: Verify `responseTypes` array includes all message types the agent should produce.
+
+**Empty response**: Model returned empty completion, agent hit max steps, or tool loop consumed output.
+
+## Supervision Issues
+
+**Checkpoint not appearing**: Verify `supervised: true` on the agent. Check that `plan_context.approved_remaining` is not `true`.
+
+**Stuck in approval loop**: Use Ctrl+C to interrupt, then restart the conversation.
+
+**approved_remaining not working**: Ensure the dispatching agent passes the full `plan_context` object in the dispatch payload.
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `VALIDATION_ERROR` | Message format invalid - failed schema validation |
+| `UNKNOWN_AGENT` | Agent ID not registered in configuration |
+| `SESSION_NOT_FOUND` | Requested session does not exist |
+| `AGENT_ERROR` | Agent execution failed (model error, tool failure) |
+| `TIMEOUT` | Request exceeded time limit |
+
+## Debugging Tips
+
+1. **Check version compatibility**: Requires `@opencode-ai/plugin` ^1.0.0
+2. **Validate JSON first**: Use `jq . .opencode/orca.json` before checking schema
+3. **Isolate with minimal config**: Start with empty `{}` and add fields incrementally
+4. **Check model availability**: Verify model name and API quota in provider dashboard
+
+## FAQ
+
+**How do I reset to defaults?**
+Delete `orca.json` and run `bunx @ex-machina/opencode-orca@latest install` to regenerate from template.
+
+**Can I use multiple orchestrators?**
+No. Orca is the primary orchestrator and manages all specialist agents.
+
+**How do I disable an agent?**
+Set `disable: true` in the agent configuration:
+```json
+{ "agents": { "researcher": { "disable": true } } }
+```


### PR DESCRIPTION
## Why This Matters

New users trying Orca faced a steep learning curve: scattered information, unclear setup steps, and no path to troubleshooting. This PR changes that.

**Before:** Users pieced together setup from README fragments and asked questions in issues.
**After:** Users go from zero to working plugin in 30 seconds, with self-service answers for everything else.

## What's New

**🚀 Quick Start Guide** — Install, configure, and run your first multi-agent workflow in under a minute.

**📖 Configuration Reference** — Complete `.opencode/orca.json` schema with every option documented. No more guessing.

**🏗️ Architecture Overview** — Understand the message protocol, agent hierarchy, and design decisions. Essential for extending or debugging.

**🤖 Custom Agent Creation** — Step-by-step guide to building your own specialized agents with examples.

**✅ Supervision & Checkpoints** — How the human-in-the-loop approval model works and how to configure it.

**🔧 Troubleshooting** — Common issues, error codes, and FAQs—so users can unblock themselves.

## User Journey Improvements

| Before | After |
|--------|-------|
| "How do I install this?" → Search README | 30-second quick start |
| "What options exist?" → Read source code | Complete config reference |
| "Why did this fail?" → Open an issue | Self-service troubleshooting |
| "How do I add an agent?" → Trial and error | Guided tutorial with examples |

## Details

- **README.md** streamlined from 154→94 lines, focused on "what is this?" with links to docs
- All internal links validated
- JSON examples verified against schemas

Closes #14