### PR TITLE
Show config error toast and fix event hook timing

### DIFF
--- a/.opencode/orca.json
+++ b/.opencode/orca.json
@@ -1,12 +1,7 @@
 {
   "settings": {
     "defaultSupervised": false,
-    "defaultModel": {
-      "model": "openai/gpt-5.2",
-      "reasoningEffort": "low",
-      "reasoningSummary": "auto",
-      "textVerbosity": "medium"
-    },
+    "defaultModel": "openai/gpt-5.2",
     "validation": { "maxRetries": 3, "wrapPlainText": true }
   },
   "agents": {
@@ -16,6 +11,7 @@
     "github": { "model": "openai/gpt-5.2", "reasoningEffort": "medium" },
     "planner": { "model": "anthropic/claude-opus-4-5" },
     "architect": { "model": "anthropic/claude-opus-4-5" },
-    "coder": { "model": "anthropic/claude-opus-4-5" }
+    "coder": { "model": "anthropic/claude-opus-4-5" },
+    "product-manager": { "disable": false }
   }
 }


### PR DESCRIPTION
## Summary

- Show error toast when `orca.json` fails to load (schema validation errors) so users know their config didn't apply
- Fix event hook timing by switching from unreliable `session.created` to first-interaction pattern
- Skip update notifier for background/sub-sessions
- Add 24hr check interval to avoid redundant update checks

## Changes

### Config error notification
When the Orca config fails to load (e.g., JSON parse error or schema validation failure), an error toast is now shown on first user interaction. Previously, config errors were silently logged and users had no indication their config wasn't loaded.

### Event hook timing fix
OpenCode plugin events only fire on user interaction, not on actual startup. The `session.created` event is unreliable for startup hooks. Changed to a first-interaction pattern using a `hasRunUpdateNotifier` flag that triggers on the first `prompt.submit` event.

### Cleanup
- Removed unused `tool.execute.before` and `tool.execute.after` hooks (weren't firing)
- Removed unused imports
- Added parent session check to skip sub-sessions

## Technical insight
Toasts only work when the TUI is ready (after first interaction), not during plugin initialization. This is why config errors and update notifications must be deferred to first interaction rather than plugin load time.