### PR TITLE
refactor: remove unused command frontmatter fields

### DIFF
--- a/.opencode/command/prune.md
+++ b/.opencode/command/prune.md
@@ -1,7 +1,5 @@
 ---
 description: Clean up merged worktrees and stale branches
-agent: github
-subtask: true
 ---
 
 ## /prune Command

--- a/.opencode/command/work.md
+++ b/.opencode/command/work.md
@@ -1,7 +1,5 @@
 ---
 description: Pick up an issue and set up development environment
-agent: executor
-subtask: true
 ---
 
 ## /work Command


### PR DESCRIPTION
## Summary
- Remove `agent` and `subtask` frontmatter keys from `.opencode/command/prune.md` and `.opencode/command/work.md`.