### PR TITLE
docs: update documentation for plan-based execution architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,38 @@
 # opencode-orca Documentation
 
-OpenCode plugin for safe agent orchestration with human-in-the-loop supervision.
+OpenCode plugin for multi-agent orchestration with plan-based execution and human-in-the-loop supervision.
 
 ## What is opencode-orca?
 
-A plugin that adds multi-agent orchestration to OpenCode with:
+A plugin that adds intelligent agent orchestration to OpenCode with:
 
-- **Supervised execution** - Checkpoint-based approval gates before agent actions
+- **Plan-based execution** - Planner creates structured plans, users approve before execution
+- **HITL supervision** - Human-in-the-loop approval for plans and deviation handling
 - **Built-in specialists** - Coder, Tester, Reviewer, Researcher, Document Writer, Architect
 - **Custom agents** - Define project-specific agents via `orca.json`
-- **Session continuity** - State tracking across agent handoffs
+- **Context threading** - Step outputs flow to subsequent steps automatically
 
 ## Documentation
 
-| Guide | Description |
-|-------|-------------|
-| [Getting Started](getting-started.md) | Installation, first run, basic usage |
-| [Configuration](configuration.md) | `orca.json` schema and options reference |
-| [Architecture](architecture.md) | System design, message flow, state machine |
-| [Custom Agents](custom-agents.md) | Defining and configuring custom specialists |
-| [Supervision](supervision.md) | Checkpoint protocol and HITL approval model |
-| [Troubleshooting](troubleshooting.md) | Common issues and solutions |
+| Guide                                | Description                                 |
+| ------------------------------------ | ------------------------------------------- |
+| [Getting Started](getting-started.md) | Installation, first run, basic usage        |
+| [Architecture](architecture.md)       | System design, tools, plan lifecycle        |
+| [Supervision](supervision.md)         | HITL approval, deviation handling           |
+| [Custom Agents](custom-agents.md)     | Defining and configuring custom specialists |
+| [Configuration](configuration.md)     | `orca.json` schema and options reference      |
+| [Troubleshooting](troubleshooting.md) | Common issues and solutions                 |
 
 ## Quick Navigation
 
 **I want to...**
 
-- **Install the plugin** - See [Getting Started](getting-started.md)
-- **Configure agent behavior** - See [Configuration](configuration.md)
-- **Add a custom agent** - See [Custom Agents](custom-agents.md)
-- **Require approval for agents** - See [Supervision](supervision.md)
-- **Understand how it works** - See [Architecture](architecture.md)
-- **Fix an error** - See [Troubleshooting](troubleshooting.md)
+- **Install the plugin** → [Getting Started](getting-started.md)
+- **Understand how it works** → [Architecture](architecture.md)
+- **Configure plan approval** → [Supervision](supervision.md)
+- **Add a custom agent** → [Custom Agents](custom-agents.md)
+- **Configure agent behavior** → [Configuration](configuration.md)
+- **Fix an error** → [Troubleshooting](troubleshooting.md)
 
 ## Quick Install
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,239 +5,365 @@ This document describes the system design and architecture decisions behind open
 ## High-Level Architecture
 
 ```
-                              +-------------------+
-                              |    User Input     |
-                              +--------+----------+
-                                       |
-                                       v
-                    +------------------+------------------+
-                    |           Orca (Orchestrator)       |
-                    |           mode: 'primary'           |
-                    +------------------+------------------+
-                                       |
-            +-----------+-+------------+---------+-+--------------+
-            |           | |            |         | |              |
-            v           v |            v         | v              v
-     +------+----+ +----+-----+ +-----+----+ +------+-----+ +-----+------+
-     |  Planner  | |  Coder   | |  Tester  | | Researcher | |  Reviewer  |
-     |  (plans)  | | (code)   | | (tests)  | |  (search)  | | (quality)  |
-     +-----------+ +----------+ +----------+ +------------+ +------------+
-                          |                      |
-                          v                      v
-                   +------+------+        +------+-------+
-                   | Doc Writer  |        |  Architect   |
-                   |   (docs)    |        |  (design)    |
-                   +-------------+        +--------------+
+                                    USER
+                                      |
+                                      v
++-----------------------------------------------------------------------------+
+|                         ORCA (Thin Orchestrator)                            |
+|                                                                             |
+|  Tools (ONLY these - no file access, no bash):                              |
+|  - orca_ask_planner: Route messages to planner                              |
+|  - orca_list_plans: List existing plans                                     |
+|  - orca_describe_plan: Get plan details                                     |
++-----------------------------------------------------------------------------+
+                                      |
+                                      v
++-----------------------------------------------------------------------------+
+|                              PLANNER                                        |
+|                                                                             |
+|  Tools: orca_ask_specialist (read-only questions)                           |
+|                                                                             |
+|  Outputs: answer | question | plan                                          |
+|  - answer: Direct response (no execution needed)                            |
+|  - question: Needs user clarification (triggers HITL)                       |
+|  - plan: Structured execution plan (triggers approval HITL)                 |
++-----------------------------------------------------------------------------+
+                                      |
+                                      v
++-----------------------------------------------------------------------------+
+|                        EXECUTION LOOP (Plugin Internal)                     |
+|                                                                             |
+|  Triggered by: Plan approval via HITL                                       |
+|  For each step: Build context -> Dispatch to specialist -> Record output    |
+|  On failure: HITL with Retry / Replan / Stop options                        |
++-----------------------------------------------------------------------------+
+                                      |
+                                      v
++-----------------------------------------------------------------------------+
+|                           SPECIALISTS                                       |
+|                                                                             |
+|  +--------+ +--------+ +--------+ +----------+ +------------+ +----------+  |
+|  | coder  | | tester | |reviewer| |researcher| |doc-writer  | |architect |  |
+|  +--------+ +--------+ +--------+ +----------+ +------------+ +----------+  |
+|                                                                             |
+|  All specialists:                                                           |
+|  - Receive tasks from execution loop (not from Orca directly)               |
+|  - Can use orca_ask_specialist for read-only questions                      |
+|  - Can use orca_describe_plan to self-serve plan context                    |
++-----------------------------------------------------------------------------+
 ```
 
 ## Agent Classes
 
-Agents are organized into three classes based on their role in the communication flow.
+Agents are organized into three classes based on their role and available tools.
 
 ### Orchestrator (Orca)
 
-The primary agent that receives all user messages and coordinates work.
+A thin orchestrator that routes all user messages to the planner. Orca is intentionally limited - it cannot read files, run commands, or dispatch directly to specialists.
 
-| Sends                   | Receives                                        |
-|-------------------------|-------------------------------------------------|
-| `question` (to Planner) | `plan`, `answer`                                |
-| `task` (to Specialists) | `success`, `failure`, `checkpoint`, `interrupt` |
+**Tools available:**
 
-**Key behavior**: Orca sends different message types to different agent classes:
-- To Planner: `question` ("How should we do X?")
-- To Specialists: `task` ("Do X")
+| Tool                 | Purpose                           |
+|----------------------|-----------------------------------|
+| `orca_ask_planner`   | Route user messages to planner    |
+| `orca_list_plans`    | List existing plans with status   |
+| `orca_describe_plan` | Get details about a specific plan |
+
+**Key behavior**: Orca is a "dumb pipe". It forwards everything to the planner and reports results back to the user. All decisions (plan approval, deviation handling) happen via HITL inside the plugin, not through Orca.
 
 ### Planner
 
-Plans complex multi-step tasks. Outputs structured plans with goals, steps, assumptions, and risks.
+Researches, plans, and answers questions. The planner is the brain of the system - it decides whether to answer directly, ask clarifying questions, or produce an execution plan.
 
-| Receives   | Responds with               |
-|------------|-----------------------------|
-| `question` | `plan`, `answer`, `failure` |
+**Tools available:**
 
-**Key behavior**: Planners plan, they don't execute or dispatch. They receive questions from Orca and respond with plans or answers.
+| Tool                  | Purpose                                 |
+|-----------------------|-----------------------------------------|
+| `orca_ask_specialist` | Ask read-only questions to other agents |
+| `orca_list_plans`     | List existing plans                     |
+| `orca_describe_plan`  | Get plan details for context            |
+
+**Outputs:**
+
+| Type       | When Used                                   | What Happens Next                |
+|------------|---------------------------------------------|----------------------------------|
+| `answer`   | Simple questions, no execution needed       | Returned to user via Orca        |
+| `question` | Needs user clarification before planning    | Triggers HITL, answers sent back |
+| `plan`     | Complex work requiring multi-step execution | Triggers approval HITL           |
+
+**Key behavior**: Planners research (via `orca_ask_specialist`), plan, and answer. They never execute work directly. When they produce a plan, the plugin handles approval and execution internally.
 
 ### Specialists
 
-Execute specific types of work. Each specialist has a focused domain and declares which message types it `accepts`:
+Execute specific types of work. Specialists receive tasks from the plugin's internal execution loop (not from Orca directly).
 
-| Agent           | Purpose                                     | Accepts                |
-|-----------------|---------------------------------------------|------------------------|
-| coder           | Implements code changes, features, fixes    | `['task']`             |
-| tester          | Writes and runs tests                       | `['task', 'question']` |
-| reviewer        | Reviews code for issues and improvements    | `['task', 'question']` |
-| researcher      | Investigates codebases, APIs, documentation | `['question']`         |
-| document-writer | Creates technical documentation             | `['task']`             |
-| architect       | Advises on system design decisions          | `['question']`         |
+| Agent           | Purpose                                     | Accepts    |
+|-----------------|---------------------------------------------|------------|
+| coder           | Implements code changes, features, fixes    | `task`     |
+| tester          | Writes and runs tests                       | `task`     |
+| reviewer        | Reviews code for issues and improvements    | `task`     |
+| researcher      | Investigates codebases, APIs, documentation | `question` |
+| document-writer | Creates technical documentation             | `task`     |
+| architect       | Advises on system design decisions          | `question` |
 
-Response types are derived from what the agent accepts:
-- `accepts: ['task']` → responds with `success`, `failure`, `checkpoint`, `interrupt`
-- `accepts: ['question']` → responds with `answer`, `failure`, `interrupt`
-- `accepts: ['task', 'question']` → can respond with any of the above
+**Tools available to all specialists:**
 
-**Key behavior**: Specialists respond with `success` for completed work or `answer` for information requests. Any specialist can emit `interrupt` to halt execution.
+| Tool                  | Purpose                                      |
+|-----------------------|----------------------------------------------|
+| `orca_ask_specialist` | Ask read-only questions to other agents      |
+| `orca_describe_plan`  | Get full plan details for additional context |
+
+**Key behavior**: Specialists execute their assigned step and return `success` or `failure`. They can ask questions to other agents (e.g., coder asks researcher about an API) via `orca_ask_specialist`, which creates a read-only session.
 
 ### Communication Flow
 
 ```
-                    User
-                      │
-                      ▼
-              ┌──────────────┐
-              │     Orca     │
-              └──────┬───────┘
-         question    │    task
-              ┌──────┴──────┐
-              ▼             ▼
-        ┌─────────┐   ┌───────────┐
-        │ Planner │   │Specialists│
-        └────┬────┘   └─────┬─────┘
-             │              │
-        plan/answer    success/failure
-                       checkpoint
-                       interrupt
+                         User
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │    Orca     │  ← Only routes to planner
+                    └──────┬──────┘
+                           │ orca_ask_planner
+                           ▼
+                    ┌─────────────┐
+                    │   Planner   │  ← Researches, plans, answers
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+          answer       question       plan
+              │            │            │
+              │            │            ▼
+              │            │     ┌────────────┐
+              │            │     │ Approval   │  ← HITL
+              │            │     │   HITL     │
+              │            │     └──────┬─────┘
+              │            │            │
+              │            ▼            ▼
+              │     ┌────────────┐  ┌──────────────┐
+              │     │ User HITL  │  │  Execution   │  ← Plugin internal
+              │     │  answers   │  │    Loop      │
+              │     └──────┬─────┘  └───────┬──────┘
+              │            │                │
+              │            ▼                ▼
+              │      back to planner   Specialists
+              │                             │
+              └─────────────────────────────┘
+                           │
+                           ▼
+                      Back to User
 ```
 
-### Checkpoint Capability
+## Tools
 
-**Checkpoints are about RISK, not work type.** Any agent performing operations with risk (not just write operations) can emit checkpoints:
+Four tools provide the dispatch capabilities for inter-agent communication.
 
-- Writing/modifying files
-- Executing shell commands
-- Sending data to external services (even read-only, e.g., PII exposure risk)
-- Making irreversible changes
+### `orca_ask_planner`
 
-Supervised agents require explicit user approval before proceeding past checkpoints.
+**Purpose**: Route user messages to the planner. This is Orca's primary tool.
+
+**Who can use it**: Orca only
+
+**Input**:
+
+```typescript
+{
+  message: string        // User's message/request
+  plan_id?: string       // Continue working on existing plan
+}
+```
+
+**Output**: One of:
+- `answer` - Planner responded directly (includes `plan_id` for continuation)
+- `completed` - Plan executed successfully (includes step results)
+- `stopped` - User stopped execution via HITL
+- `rejected` - User rejected the plan via HITL
+- `failure` - Something went wrong
+
+**Key behavior**: All HITL (planner questions, plan approval, deviation handling) happens internally. Orca just receives the final result.
+
+### `orca_list_plans`
+
+**Purpose**: Discover existing plans for resume/status checks.
+
+**Who can use it**: Everyone (Orca, Planner, Specialists)
+
+**Input**: None
+
+**Output**: Array of plan summaries with `plan_id`, `goal`, `status`, `step_progress`
+
+### `orca_describe_plan`
+
+**Purpose**: Get full details about a specific plan.
+
+**Who can use it**: Everyone (Orca, Planner, Specialists)
+
+**Input**: `{ plan_id: string }`
+
+**Output**: Full plan details including steps, assumptions, risks, verification criteria, and execution state.
+
+**Key behavior**: Enables agents to self-serve context. A specialist executing step 3 can look up the plan's assumptions if needed.
+
+### `orca_ask_specialist`
+
+**Purpose**: Ask read-only questions to non-supervised agents. Supports multi-turn conversations.
+
+**Who can use it**: Planner and Specialists (NOT Orca)
+
+**Input**:
+```typescript
+{
+  agent_id: string       // Target agent
+  session_id?: string    // Continue existing conversation
+  question: string       // The question to ask
+}
+```
+
+**Output**: Answer content with `session_id` for potential continuation.
+
+**Key behavior**: Creates a read-only session - the target agent cannot write files or execute dangerous commands. This allows safe research mid-task.
+
+## Plan Lifecycle
+
+Every interaction creates or continues a plan. Plans are persisted to `.opencode/plans/{plan_id}.json`.
+
+### Plan States
+
+```
+drafting → pending_approval → approved → in_progress → completed
+                ↓                              ↓
+         changes_requested                  failed
+                ↓
+           (back to drafting)
+
+pending_approval → rejected (terminal)
+```
+
+| State             | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| `drafting`          | Planner is working, may ask clarifying questions |
+| `pending_approval`  | Plan ready, waiting for user approval via HITL   |
+| `changes_requested` | User requested changes, back to planner          |
+| `approved`          | User approved, ready for execution               |
+| `in_progress`       | Execution loop is running steps                  |
+| `completed`         | All steps finished successfully                  |
+| `failed`            | A step failed and user chose to stop             |
+| `rejected`          | User rejected the plan entirely                  |
+
+### Draft Plans
+
+Even before a plan is fully formed, a **draft plan** is created to serve as the continuity token. This means:
+- User asks "Refactor the auth system"
+- Planner creates draft plan, needs clarification
+- Planner asks "OAuth or session-based?" via HITL
+- User answers, planner continues with same plan context
+- Eventually plan is finalized and goes through approval
+
+Draft plans are lightweight and can be pruned if never finalized.
+
+## Context Threading
+
+Step outputs flow to subsequent steps, eliminating redundant research.
+
+### What Flows Forward
+
+| Field        | Description                                |
+| ------------ | ------------------------------------------ |
+| `summary`      | Brief summary of what was accomplished     |
+| `artifacts`    | Files created/modified                     |
+| `key_findings` | Important discoveries (for research steps) |
+
+### Step Prompt Structure
+
+Each specialist receives:
+1. **Plan reference** - `plan_id` and `goal` (can fetch more via `orca_describe_plan`)
+2. **Step description** - What this step should accomplish
+3. **Previous step summaries** - What prior steps accomplished
+4. **Relevant files** - Accumulated from plan + previous step artifacts
+
+This keeps prompts lean while providing necessary context. Agents can self-serve additional detail via `orca_describe_plan`.
 
 ## Message Protocol
 
-All inter-agent communication uses typed messages validated by Zod discriminated unions. Messages use a **flattened structure** where fields go directly on the message with a `type` discriminant (no `payload` wrapper).
+All inter-agent communication uses typed messages validated by Zod schemas.
 
-### Message Types
+### Planner Response Types
 
-**Request types** (sent to agents via `DispatchPayload`):
+| Type     | Purpose                     | Triggers                   |
+| -------- | --------------------------- | -------------------------- |
+| `answer`   | Direct information response | Return to Orca             |
+| `question` | Needs user clarification    | HITL, then back to planner |
+| `plan`     | Structured execution plan   | Approval HITL              |
 
-| Type       | Sender | Recipient            | Purpose                   |
-|------------|--------|----------------------|---------------------------|
-| `question` | Orca   | Planner, Specialists | Request information       |
-| `task`     | Orca   | Specialists          | Assign work for execution |
+### Specialist Response Types
 
-**Response types** (returned by agents in `DispatchResponse`):
+| Type    | Purpose                     |
+| ------- | --------------------------- |
+| `success` | Work completed successfully |
+| `failure` | Error during execution      |
 
-| Type         | Sender      | Recipient | Purpose                         |
-|--------------|-------------|-----------|---------------------------------|
-| `answer`     | Planner     | Orca      | Information response            |
-| `plan`       | Planner     | Orca      | Execution plan proposal         |
-| `success`    | Specialists | Caller    | Work completed successfully     |
-| `failure`    | Specialists | Caller    | Reports error with task         |
-| `checkpoint` | Specialists | Caller    | Requires user approval          |
-| `interrupt`  | Specialists | Caller    | Halt execution, needs attention |
+### HITL Question Schema
 
-### Two Communication Patterns
-
-The protocol distinguishes between **information retrieval** and **work execution**:
-
-```
-Question/Answer (information):
-  Orca/Planner --question--> Agent --answer--> Caller
-
-Task/Success (execution):
-  Orca --task--> Specialist --success/failure--> Orca
-```
-
-This separation ensures:
-- Planners never execute work (they ask questions, they don't dispatch tasks)
-- The response type reflects what was requested (information vs. completion)
-- Clear semantics for each message type
-
-### Dispatch Envelope
-
-Inter-agent communication uses an envelope structure. The `agent_id` and `session_id` live on the envelope, NOT on individual messages:
+All HITL questions use a consistent schema:
 
 ```typescript
-// What is sent to agents
-type DispatchPayload = {
-  agent_id: string,        // Target agent
-  session_id?: string,     // For resuming conversations
-  message: Message         // The actual message (task, question, etc.)
-}
-
-// What is returned by agents  
-type DispatchResponse = {
-  session_id?: string,     // For continuing conversation
-  message: Message         // The actual message (answer, plan, etc.)
+{
+  header: string           // Tab label (max 30 chars)
+  question: string         // Full question text
+  options: Array<{
+    label: string
+    description?: string
+  }>
+  multiple?: boolean       // Allow multiple selections
+  custom?: boolean         // Allow freeform input
 }
 ```
 
-## Session Continuity
-
-Sessions maintain context across agent handoffs via the dispatch envelope:
-
-- **session_id**: On `DispatchPayload`/`DispatchResponse`, identifies the conversation
-- **plan_context**: Tracks plan execution state (goal, step_index, approved_remaining)
-
-```
-User Request -> Orca creates session -> Dispatches with session_id
-             -> Agent responds with same session_id -> Orca continues
-```
-
-## State Machine
-
-```
-          +--------+                    +------------+
-          |  IDLE  |  <-- checkpoint    | EXECUTING  |
-          |        |      approval -->  |            |
-          +---+----+                    +-----+------+
-              |                               |
-              | user message                  | task/question dispatch
-              v                               v
-         [Route to Orca]              [Agent processing]
-```
-
-- **IDLE**: Waiting for user input or checkpoint approval
-- **EXECUTING**: Processing request through agent pipeline
-- Checkpoint pauses execution until user approves
-- Completion returns to IDLE state
+The **emitter** (agent or plugin) is responsible for providing all fields. The HITL system passes through without transformation.
 
 ## Design Decisions
 
-### Zod Discriminated Unions for Validation
+### 1. Orca is a Dumb Pipe
 
-Type-safe message handling with runtime validation:
-- Compile-time type inference from schemas
-- Runtime validation catches malformed messages early
-- Single source of truth for message structure
-- Discriminant field enables exhaustive switch handling
+Orca has only 3 tools and cannot read files or run commands. This keeps it focused on routing and prevents it from making execution decisions.
 
-### Question/Answer vs Task/Success
+### 2. Everything is a Plan
 
-Two distinct communication patterns serve different purposes:
+Every planner interaction creates or continues a plan. Even simple Q&A gets a `plan_id` for potential continuation. This provides a consistent continuity model.
 
-| Pattern     | Request    | Response            | Purpose            |
-|-------------|------------|---------------------|--------------------|
-| Information | `question` | `answer`            | Research, analysis |
-| Execution   | `task`     | `success`/`failure` | Work completion    |
+### 3. All HITL is Internal to Plugin
 
-This ensures semantic clarity: questions get answers, tasks get results.
+Plan approval, deviation handling, and planner questions all use `question.ask()` inside the plugin. LLMs cannot be trusted as gates - deterministic plugin logic handles all decisions.
 
-### Checkpoint Protocol for Supervision
+### 4. Two-Question HITL Pattern
 
-Human-in-the-loop safety for risky operations:
-- Any agent can emit checkpoints (not just execution agents)
-- Risk includes read operations (e.g., PII exposure to untrusted services)
-- Users can approve individual steps or "approve all remaining"
-- Checkpoints pause execution until explicit approval
+For plugin-controlled decisions (approval, deviations), we use two questions:
+1. **Action** (`custom: false`) - Deterministic choice from predefined options
+2. **Context** (`custom: true`) - Optional freeform guidance
 
-### Session-Based Context Passing
+This keeps logic deterministic while allowing user flexibility.
 
-Maintains conversation state across agent handoffs:
-- Agents see relevant history from parent session
-- Parent-child linking preserves execution trace
-- Enables coherent multi-step task completion
+### 5. Emitter Owns the Format
 
-### Response Validation with Retry
+Any agent or plugin emitting HITL questions provides all display details (header, question, options). The HITL system is a pass-through.
 
-Ensures agents respond in correct format:
-- Validates all agent responses against expected schemas
-- On validation failure, re-prompts agent with correction guidance
-- Configurable retry count prevents infinite loops
+### 6. Execution is Plugin-Internal
+
+When a user approves a plan via HITL, the plugin executes it internally. Orca just receives the final result. This prevents Orca from needing to manage execution state.
+
+### 7. Context Threading Over Session History
+
+Rather than relying on session history, we explicitly thread step outputs (summaries, artifacts, key findings) to subsequent steps. This keeps context lean and relevant.
+
+### 8. Session-Level Permissions
+
+`orca_ask_specialist` creates read-only sessions. The target agent cannot write files - bash defaults to `ask`, writes are denied. This enables safe mid-task research.
+
+### 9. Plans are the Continuity Artifact
+
+Plans (not sessions) are the primary continuity mechanism. The `plan_id` allows resuming work across sessions. Planner session IDs are stored in the plan file for context continuity on revisions.
+
+### 10. Retry Count Limits
+
+Failed steps can be retried up to 10 times. After that, the Retry option is removed - user must Replan or Stop. This prevents infinite loops.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,65 +6,104 @@ Configure opencode-orca via `.opencode/orca.json` in your project root.
 
 ```json
 {
-  "settings": { ... },
-  "agents": { ... }
+  "$schema": "./orca.schema.json",
+  "orca": { ... },
+  "planner": { ... },
+  "agents": { ... },
+  "settings": { ... }
 }
 ```
 
-Both top-level keys are optional. The file itself is optional.
+All keys are optional. The file itself is optional. The plugin auto-generates `orca.schema.json` for editor autocomplete.
+
+## Top-Level Keys
+
+| Key      | Purpose                                        |
+| -------- | ---------------------------------------------- |
+| `$schema`  | Path to JSON schema for editor support         |
+| `orca`     | Restricted overrides for the orca orchestrator |
+| `planner`  | Restricted overrides for the planner agent     |
+| `agents`   | Specialist agent configs (override or add new) |
+| `settings` | Global plugin settings                         |
+
+## Orca & Planner Configuration
+
+The `orca` and `planner` agents have restricted configuration - only these fields can be overridden:
+
+| Option      | Type         | Description                        |
+| ----------- | ------------ | ---------------------------------- |
+| `model`       | string       | Model identifier                   |
+| `temperature` | number (0-2) | Sampling temperature               |
+| `top_p`       | number (0-1) | Nucleus sampling parameter         |
+| `maxSteps`    | number       | Maximum steps before agent stops   |
+| `color`       | string       | Hex color for UI display (`#RRGGBB`) |
+
+**Example:**
+```json
+{
+  "orca": {
+    "model": "claude-sonnet-4-20250514",
+    "maxSteps": 20
+  },
+  "planner": {
+    "model": "claude-sonnet-4-20250514",
+    "temperature": 0.7
+  }
+}
+```
+
+> **Note**: You cannot override prompts, tools, or permissions for orca/planner - these are managed by the plugin to ensure correct orchestration behavior.
 
 ## Settings
 
 Global plugin settings under the `settings` key.
 
-| Option                     | Type          | Default | Description                                            |
-|----------------------------|---------------|---------|--------------------------------------------------------|
-| `defaultSupervised`        | boolean       | `false` | Require user approval for all agents by default        |
-| `defaultModel`             | string        |         | Default model for agents without explicit model config |
-| `updateNotifier`           | boolean       | `true`  | Show notifications about plugin updates                |
-| `validation.maxRetries`    | number (0-10) | `3`     | Max retries when agent response fails validation       |
-| `validation.wrapPlainText` | boolean       | `true`  | Wrap plain text responses in result messages           |
+| Option                   | Type          | Default | Description                                      |
+| ------------------------ | ------------- | ------- | ------------------------------------------------ |
+| `defaultModel`             | string        |         | Default model for agents without explicit config |
+| `updateNotifier`           | boolean       | `true`    | Show notifications about plugin updates          |
+| `validation.maxRetries`    | number (0-10) | `3`       | Max retries when agent response fails validation |
+| `validation.wrapPlainText` | boolean       | `true`    | Wrap plain text responses in result messages     |
 
 ## Agent Configuration
 
-Override built-in agents or define custom ones under the `agents` key.
+Override built-in specialists or define custom ones under the `agents` key.
 
-| Option        | Type                              | Description                                            |
-| ------------- | --------------------------------- | ------------------------------------------------------ |
-| `model`         | string                            | Model identifier (e.g., `claude-sonnet-4-20250514`)    |
-| `temperature`   | number (0-2)                      | Sampling temperature                                   |
-| `top_p`         | number (0-1)                      | Nucleus sampling parameter                             |
-| `prompt`        | string                            | System prompt (overrides built-in prompt)              |
-| `tools`         | `Record<string, boolean>`         | Enable/disable specific tools                          |
-| `disable`       | boolean                           | Disable this agent entirely                            |
-| `description`   | string                            | Agent description shown in UI                          |
-| `mode`          | `'subagent' \| 'primary' \| 'all'` | Agent visibility mode                                  |
-| `color`         | string                            | Hex color for UI display (`#RRGGBB`)                   |
-| `maxSteps`      | number                            | Maximum steps before agent stops                       |
-| `permission`    | PermissionConfig                  | Permission overrides (see below)                       |
-| `supervised`    | boolean                           | Require user approval before dispatch                  |
-| `accepts`       | `('task' \| 'question')[]`          | Message types this agent accepts (see below)           |
-| `specialist`    | boolean                           | Include in Orca's specialist list                      |
+| Option      | Type                               | Description                                         |
+| ----------- | ---------------------------------- | --------------------------------------------------- |
+| `model`       | string                             | Model identifier (e.g., `claude-sonnet-4-20250514`) |
+| `temperature` | number (0-2)                       | Sampling temperature                                |
+| `top_p`       | number (0-1)                       | Nucleus sampling parameter                          |
+| `prompt`      | string                             | System prompt (overrides built-in prompt)           |
+| `tools`       | `Record<string, boolean>`          | Enable/disable specific tools                       |
+| `disable`     | boolean                            | Disable this agent entirely                         |
+| `description` | string                             | Agent description shown in UI and to planner        |
+| `mode`        | `'subagent' \| 'primary' \| 'all'` | Agent visibility mode                               |
+| `color`       | string                             | Hex color for UI display (`#RRGGBB`)                |
+| `maxSteps`    | number                             | Maximum steps before agent stops                    |
+| `permission`  | PermissionConfig                   | Permission overrides (see below)                    |
+| `accepts`     | `('task' \| 'question')[]`         | Message types this agent accepts                    |
+| `specialist`  | boolean                            | Include in planner's specialist list                |
 
 ### Accepts (Input Types)
 
 The `accepts` array defines what message types can be dispatched TO an agent:
 
-| Value        | Purpose                 |
-|--------------|-------------------------|
-| `'task'`     | Work execution requests |
-| `'question'` | Information requests    |
+| Value      | Purpose                 | Typical Use                    |
+| ---------- | ----------------------- | ------------------------------ |
+| `'task'`     | Work execution requests | Agents that modify files/state |
+| `'question'` | Information requests    | Research and analysis agents   |
 
-Default for specialists: `['task', 'question']`. Response types are derived automatically.
-
-> **Note**: `orca` and `planner` are protected and cannot be overridden via user config.
+Default: `[]` (must be explicitly set for custom agents). Response types are derived automatically:
+- `accepts: ['task']` → responds with `success` or `failure`
+- `accepts: ['question']` → responds with `answer` or `failure`
 
 ### Permission Config
 
 Fine-grained permission control per agent.
 
-| Permission           | Type                            | Description              |
-|----------------------|---------------------------------|--------------------------|
+| Permission         | Type                            | Description              |
+| ------------------ | ------------------------------- | ------------------------ |
 | `edit`               | `'ask' \| 'allow' \| 'deny'`    | File editing permission  |
 | `bash`               | enum or `Record<pattern, enum>` | Shell command permission |
 | `webfetch`           | `'ask' \| 'allow' \| 'deny'`    | Web fetch permission     |
@@ -83,53 +122,48 @@ For `bash`, you can specify per-command patterns:
 }
 ```
 
+## Plan Storage
+
+Plans are automatically stored in `.opencode/plans/` as JSON files. Each plan has:
+- A unique `plan_id` (e.g., `pln_abc123def456`)
+- Status tracking (drafting, approved, in_progress, completed, failed, etc.)
+- Execution state including step results and context
+
+Plan files are managed by the plugin and should not be edited manually.
+
 ## Examples
 
-### Enable Supervision Globally
+### Override a Built-in Specialist
 
-Require approval before any agent executes:
-
-```json
-{
-  "settings": {
-    "defaultSupervised": true
-  }
-}
-```
-
-### Override a Built-in Agent
-
-Change the coder agent's model and temperature:
+Change the coder agent's model and step limit:
 
 ```json
 {
   "agents": {
     "coder": {
       "model": "claude-sonnet-4-20250514",
-      "temperature": 0.3,
       "maxSteps": 50
     }
   }
 }
 ```
 
-### Add a Custom Agent
+### Add a Custom Specialist
 
-Define a project-specific specialist:
+Define a project-specific agent:
 
 ```json
 {
   "agents": {
     "api-designer": {
-      "description": "Designs REST API endpoints",
+      "description": "Designs REST API endpoints following project conventions",
       "model": "claude-sonnet-4-20250514",
       "mode": "subagent",
       "specialist": true,
-      "prompt": "You are an API design specialist...",
+      "prompt": "You are an API design specialist. Design RESTful endpoints following best practices. Use orca_ask_specialist to research existing patterns in the codebase.",
       "accepts": ["question"],
-      "supervised": true,
       "permission": {
-        "edit": "allow",
+        "edit": "deny",
         "bash": "deny"
       }
     }
@@ -137,15 +171,58 @@ Define a project-specific specialist:
 }
 ```
 
-### Customize Validation and Notifications
+### Create a Read-Only Research Agent
 
 ```json
 {
+  "agents": {
+    "security-auditor": {
+      "description": "Audits code for security vulnerabilities",
+      "mode": "subagent",
+      "specialist": true,
+      "accepts": ["question"],
+      "prompt": "You are a security specialist. Analyze code for vulnerabilities. You cannot modify files - report findings only.",
+      "permission": {
+        "edit": "deny",
+        "bash": {
+          "grep *": "allow",
+          "find *": "allow",
+          "*": "deny"
+        }
+      }
+    }
+  }
+}
+```
+
+### Full Configuration Example
+
+```json
+{
+  "$schema": "./orca.schema.json",
+  "orca": {
+    "maxSteps": 15
+  },
+  "planner": {
+    "model": "claude-sonnet-4-20250514",
+    "temperature": 0.7
+  },
+  "agents": {
+    "coder": {
+      "maxSteps": 50
+    },
+    "db-migrator": {
+      "description": "Creates database migrations",
+      "mode": "subagent",
+      "specialist": true,
+      "accepts": ["task"],
+      "prompt": "You are a database migration specialist..."
+    }
+  },
   "settings": {
-    "updateNotifier": false,
+    "defaultModel": "claude-sonnet-4-20250514",
     "validation": {
-      "maxRetries": 1,
-      "wrapPlainText": false
+      "maxRetries": 2
     }
   }
 }
@@ -153,9 +230,12 @@ Define a project-specific specialist:
 
 ## Validation
 
-The plugin validates `orca.json` on load. Invalid configs produce clear error messages with paths and expected types. Fix all validation errors before the plugin will load.
+The plugin validates `orca.json` on load using Zod schemas. Invalid configs produce clear error messages with paths and expected types. Fix all validation errors before the plugin will load.
+
+The generated `orca.schema.json` file provides editor autocomplete and inline validation in VS Code and other editors that support JSON Schema.
 
 ## See Also
 
 - [Custom Agents](custom-agents.md) - Detailed guide on creating agents
-- [Supervision](supervision.md) - How approval checkpoints work
+- [Supervision](supervision.md) - HITL approval and deviation handling
+- [Architecture](architecture.md) - System design and plan lifecycle

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -12,62 +12,64 @@ Built-in agents: `orca`, `planner`, `coder`, `tester`, `reviewer`, `researcher`,
 
 For overrides, all fields are optional (they merge). For new agents, include:
 
-| Field         | Purpose                                              |
-| ------------- | ---------------------------------------------------- |
-| `mode`          | Set to `'subagent'` for agents dispatched by Orca      |
-| `description`   | Shown in UI; helps Orca select the right agent       |
-| `prompt`        | System prompt defining agent behavior                |
-| `accepts`       | Message types this agent accepts (`'task'`, `'question'`) |
-| `specialist`    | Set to `true` to include in Orca's specialist list     |
+| Field         | Purpose                                                   |
+|---------------|-----------------------------------------------------------|
+| `mode`        | Set to `'subagent'` for agents dispatched by Orca         |
+| `description` | Shown in UI; helps planner select the right agent         |
+| `prompt`      | System prompt defining agent behavior                     |
+| `accepts`     | Message types this agent accepts (`'task'`, `'question'`) |
+| `specialist`  | Set to `true` to include in planner's specialist list     |
 
 See [Configuration Reference](configuration.md) for all fields.
 
-> **Note**: `orca` and `planner` are protected agents and cannot be overridden.
+> **Note**: `orca` and `planner` have restricted configuration - only model, temperature, top_p, maxSteps, and color can be changed. See [Configuration Reference](configuration.md) for details.
 
-## Protocol Requirements
+## Agent Roles in the System
 
-Agents receive messages via `DispatchPayload` and respond with flat JSON messages (no wrapper):
+Custom agents fit into the execution flow based on their configuration:
 
-```typescript
-// What agents receive
-DispatchPayload: { agent_id, session_id?, message }
-
-// What agents return (flat structure)
-{ "type": "answer", "content": "..." }
 ```
+User → Orca → Planner → [Plan Approval HITL] → Execution Loop → Specialists
+                                                                    ↑
+                                                          Your custom agent
+```
+
+**Specialists** (custom agents with `specialist: true`):
+- Receive tasks from the plugin's internal execution loop
+- Are assigned to plan steps by the planner
+- Can use `orca_ask_specialist` for read-only questions to other agents
+- Can use `orca_describe_plan` to get plan context
 
 ## Input Types (`accepts`)
 
 The `accepts` array defines what message types an agent can receive:
 
-| Type       | Purpose                              | Default for specialists |
-| ---------- | ------------------------------------ | ----------------------- |
-| `task`       | Work execution requests              | Yes                     |
-| `question`   | Information requests                 | Yes                     |
+| Type     | Purpose                 | Typical Use                    |
+| -------- | ----------------------- | ------------------------------ |
+| `task`     | Work execution requests | Agents that modify files/state |
+| `question` | Information requests    | Research and analysis agents   |
 
-Specialists default to `accepts: ['task', 'question']`. Override to restrict:
-- `accepts: ['task']` — only work requests (e.g., coder)
-- `accepts: ['question']` — only information requests (e.g., researcher)
+For custom agents, `accepts` defaults to `['task', 'question']`. Built-in specialists may be overridden. Set based on agent purpose:
+- `accepts: ['task', 'question']` — executes work (e.g., coder, tester)
+- `accepts: ['question']` — answers questions only (e.g., researcher, architect)
+- `accepts: ['task']` — only does work (e.g., document-writer) 
 
 ## Response Types
 
-Response types are derived automatically from `accepts`:
+Agents return flat JSON messages based on their role:
 
-| If agent accepts | Can respond with                       |
-| ---------------- | -------------------------------------- |
-| `task`             | `success`, `failure`, `checkpoint`         |
-| `question`         | `answer`, `failure`                        |
-| (any specialist) | `interrupt` (always available)           |
+| If agent accepts | Responds with    |
+| ---------------- | ---------------- |
+| `task`             | `success`, `failure` |
+| `question`         | `answer`, `failure`  |
 
 ### Message Fields
 
-| Type         | Fields                                             |
-| ------------ | -------------------------------------------------- |
-| `answer`       | `content`, `sources?`, `annotations?`                  |
-| `success`      | `summary`, `artifacts?`, `verification?`, `notes?`       |
-| `failure`      | `code`, `message`, `cause?`                            |
-| `checkpoint`   | `prompt`, `step_index?`, `plan_goal?`                  |
-| `interrupt`    | `reason`                                             |
+| Type    | Fields                                     |
+| ------- | ------------------------------------------ |
+| `answer`  | `content`, `sources?`, `annotations?`            |
+| `success` | `summary`, `artifacts?`, `verification?`, `notes?` |
+| `failure` | `code`, `message`, `cause?`                      |
 
 Error codes: `VALIDATION_ERROR`, `UNKNOWN_AGENT`, `SESSION_NOT_FOUND`, `AGENT_ERROR`, `TIMEOUT`
 
@@ -92,6 +94,19 @@ Error codes: `VALIDATION_ERROR`, `UNKNOWN_AGENT`, `SESSION_NOT_FOUND`, `AGENT_ER
 }
 ```
 
+## Tools Available to Custom Agents
+
+Specialist agents have access to these dispatch tools:
+
+| Tool                | Purpose                                      |
+| ------------------- | -------------------------------------------- |
+| `orca_ask_specialist` | Ask read-only questions to other agents      |
+| `orca_describe_plan`  | Get full plan details for additional context |
+
+**Example**: A custom `security-reviewer` agent analyzing code could use `orca_ask_specialist` to ask the `researcher` about known vulnerabilities in a dependency.
+
+**Note**: These tools create read-only sessions - the target agent cannot modify files.
+
 ## Complete Example: Security Reviewer
 
 ```json
@@ -102,9 +117,8 @@ Error codes: `VALIDATION_ERROR`, `UNKNOWN_AGENT`, `SESSION_NOT_FOUND`, `AGENT_ER
       "mode": "subagent",
       "model": "claude-sonnet-4-20250514",
       "specialist": true,
-      "supervised": true,
       "accepts": ["question"],
-      "prompt": "You are a security specialist. Analyze code for vulnerabilities including injection attacks, authentication flaws, and data exposure. Cite file locations. Ask questions if scope is unclear.",
+      "prompt": "You are a security specialist. Analyze code for vulnerabilities including injection attacks, authentication flaws, and data exposure. Cite file locations. Use orca_ask_specialist to research CVEs or dependency issues if needed.",
       "permission": { "edit": "deny", "bash": "deny" }
     }
   }
@@ -112,11 +126,33 @@ Error codes: `VALIDATION_ERROR`, `UNKNOWN_AGENT`, `SESSION_NOT_FOUND`, `AGENT_ER
 ```
 
 This agent:
-- `specialist: true` — appears in Orca's specialist list
+- `specialist: true` — appears in planner's specialist list for plan steps
 - `accepts: ["question"]` — only receives information requests (read-only analysis)
-- `supervised: true` — requires approval before dispatch
+- `permission` — restricted from writing files or running bash
 
-Use it: `@orca Review the auth module for security issues`
+Use it: The planner will assign this agent to security-related steps in plans.
+
+## Complete Example: Database Migrator
+
+```json
+{
+  "agents": {
+    "db-migrator": {
+      "description": "Creates and manages database migrations",
+      "mode": "subagent",
+      "model": "claude-sonnet-4-20250514",
+      "specialist": true,
+      "accepts": ["task"],
+      "prompt": "You are a database migration specialist. Create migrations using the project's migration framework. Always create reversible migrations. Test migrations locally before marking complete."
+    }
+  }
+}
+```
+
+This agent:
+- `specialist: true` — available for database migration steps
+- `accepts: ["task"]` — executes work (creates migration files)
+- No permission restrictions — can write files
 
 ## Overriding Built-in Agents
 
@@ -126,7 +162,6 @@ Use the same name; only specify fields to change:
 {
   "agents": {
     "coder": {
-      "supervised": true,
       "model": "claude-sonnet-4-20250514",
       "maxSteps": 30
     }
@@ -134,18 +169,30 @@ Use the same name; only specify fields to change:
 }
 ```
 
-This adds supervision to coder while keeping its default prompt and tools.
+This changes the model and step limit while keeping the default prompt and tools.
 
 ## Testing Custom Agents
 
 1. Verify config loads without errors (check OpenCode startup)
-2. Dispatch to your agent via `@orca` with a relevant task or question
-3. Confirm responses match the expected types for what the agent `accepts`
-4. Check supervision gates appear if `supervised: true`
+2. Ask Orca to create a plan involving your agent's specialty
+3. Confirm your agent appears in the plan steps
+4. Approve the plan and verify your agent executes correctly
+5. Check responses match the expected types for what the agent `accepts`
 
 Failed validations retry up to `validation.maxRetries` times before returning failure.
 
+## Plan Context Awareness
+
+When your agent executes as part of a plan, it receives context about:
+- The overall plan goal
+- Which step it's executing
+- Summaries from previous steps
+- Relevant files accumulated from the plan
+
+Your agent can fetch additional context using `orca_describe_plan` if needed.
+
 ## See Also
 
+- [Architecture](architecture.md) - System design and agent roles
 - [Configuration Reference](configuration.md) - All configuration options
-- [Supervision](supervision.md) - Approval checkpoints
+- [Supervision](supervision.md) - HITL approval and deviation handling

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,7 @@ bunx @ex-machina/opencode-orca@latest install
 This command:
 - Adds `@ex-machina/opencode-orca` to the `plugin` array in your `opencode.jsonc`
 - Creates a default configuration file at `.opencode/orca.json`
+- Generates `orca.schema.json` for editor autocomplete
 
 ### 2. Verify installation
 
@@ -53,19 +54,25 @@ In the OpenCode chat, try:
 @orca Help me refactor the authentication module
 ```
 
-Orca will analyze your request, create a plan, and coordinate specialist agents to execute it.
+Orca will route your request to the planner, which will analyze it and create an execution plan.
 
 ## What happens next
 
 When you interact with Orca:
 
-1. **Planner** analyzes your request and creates an execution plan
-2. **You approve** the plan (or request changes)
-3. **Specialist agents** execute each step (coder, tester, reviewer, etc.)
-4. **Orca** coordinates the workflow and reports results
+1. **Orca** routes your request to the planner
+2. **Planner** may ask clarifying questions via HITL prompts
+3. **Planner** creates a structured execution plan
+4. **You review and approve** the plan (or request changes)
+5. **Execution loop** runs each step with the appropriate specialist
+6. **Context flows** between steps - each specialist sees what previous steps accomplished
+7. **On failure**, you choose to Retry, Replan, or Stop
+
+Plans are saved to `.opencode/plans/` so you can resume or review them later.
 
 ## Next steps
 
-- [Configuration](./configuration.md) - Customize models, validation, and agent behavior
+- [Architecture](./architecture.md) - Understand the system design and tools
+- [Supervision](./supervision.md) - Learn about HITL approval and deviation handling
 - [Custom Agents](./custom-agents.md) - Create your own specialist agents
-- [Supervision](./supervision.md) - Configure approval gates for agent actions
+- [Configuration](./configuration.md) - Customize models and agent behavior

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -1,128 +1,230 @@
 # Supervision
 
-Supervision provides human-in-the-loop approval gates that prevent agents from executing tasks without explicit user consent. This safety mechanism protects against unintended destructive operations or external side effects.
+Supervision provides human-in-the-loop (HITL) control over agent execution. This safety mechanism ensures users maintain control over planning decisions, execution approval, and failure recovery.
 
-## How It Works
+## Supervision Model
 
-When an agent is supervised, Orca cannot dispatch tasks directly. Instead, the plugin returns a **checkpoint** message that pauses execution and asks the user to approve before proceeding.
+Orca uses a **plan-based supervision model** where human approval gates are built into the workflow:
+
+1. **Plan Approval** - Users approve plans before execution begins
+2. **Deviation Handling** - Users decide how to handle failures (retry, replan, stop)
+3. **Planner Questions** - Users answer clarifying questions during planning
+
+All HITL interactions happen inside the plugin via `question.ask()`. LLMs cannot bypass these gates - deterministic plugin logic enforces all decisions.
 
 ```
-    Orca                  Plugin                  Agent
-      |                     |                      |
-      |--- dispatch task -->|                      |
-      |                     |-- check supervised --|
-      |<-- checkpoint ------|                      |
-      |                     |                      |
-   [User approves]          |                      |
-      |                     |                      |
-      |--- re-dispatch ---->|                      |
-      |  (approved: true)   |--- execute task ---->|
-      |                     |<---- response -------|
-      |<--- response -------|                      |
+                    User Request
+                          │
+                          ▼
+                    ┌───────────┐
+                    │  Planner  │
+                    └─────┬─────┘
+                          │
+         ┌────────────────┼────────────────┐
+         ▼                ▼                ▼
+     answer           question           plan
+         │                │                │
+         │                ▼                ▼
+         │         ┌───────────┐    ┌───────────┐
+         │         │   HITL    │    │   HITL    │
+         │         │ Questions │    │ Approval  │
+         │         └─────┬─────┘    └─────┬─────┘
+         │               │                │
+         │               ▼                ▼
+         │         back to planner   Execute Plan
+         │                                │
+         │                                ▼
+         │                         ┌───────────┐
+         │                         │ On Failure│
+         │                         │   HITL    │──► Retry / Replan / Stop
+         │                         └───────────┘
+         │                                │
+         └────────────────────────────────┘
+                          │
+                          ▼
+                    Back to User
 ```
 
-## Enabling Supervision
+## HITL Touchpoints
 
-### Per-Agent
+### 1. Planner Questions
 
-Set `supervised: true` on specific agents:
+When the planner needs clarification before creating a plan, it emits questions that trigger HITL.
 
-```json
+**Example**: Planner asks about authentication approach:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Auth Type │ Database │ Priority │ Confirm               │
+├─────────────────────────────────────────────────────────┤
+│ What authentication approach do you want?               │
+│                                                         │
+│ 1. OAuth      - Third-party providers (Google, GitHub)  │
+│ 2. Session    - Traditional cookie-based sessions       │
+│ 3. JWT        - Stateless JSON Web Tokens               │
+│ 4. Type your own answer                                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Key behaviors**:
+- Planner can batch multiple questions in a single HITL call
+- User sees tabs for each question, answers all at once
+- `custom: true` always - user can type an answer not in the options
+- Answers are sent back to planner to continue planning
+
+### 2. Plan Approval
+
+When the planner produces a complete plan, users must approve before execution begins.
+
+**Example**: Approval prompt:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Decision │ Feedback │ Confirm                           │
+├─────────────────────────────────────────────────────────┤
+│ Review the plan:                                        │
+│                                                         │
+│ Goal: Add user authentication to the API                │
+│ Steps: 4                                                │
+│   1. [researcher] Investigate existing auth patterns    │
+│   2. [coder] Implement auth middleware                  │
+│   3. [coder] Add login/logout endpoints                 │
+│   4. [tester] Write auth integration tests              │
+│                                                         │
+│ Files affected: src/middleware/*, src/routes/auth.ts    │
+│ Risks: Breaking change to existing sessions             │
+│                                                         │
+│ What would you like to do?                              │
+│                                                         │
+│ 1. Approve          - Execute this plan                 │
+│ 2. Request Changes  - Send back to planner for revision │
+│ 3. Reject           - Cancel this plan entirely         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Options**:
+
+| Option          | What Happens                                      |
+|-----------------|---------------------------------------------------|
+| Approve         | Plan executes, user can provide optional feedback |
+| Request Changes | Feedback sent to planner, revises and resubmits   |
+| Reject          | Plan cancelled, returned to conversation          |
+
+### 3. Deviation Handling
+
+When a step fails during execution, users choose how to proceed.
+
+**Example**: Failure prompt:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Action │ Context │ Confirm                              │
+├─────────────────────────────────────────────────────────┤
+│ Step 2 failed: "Implement auth middleware"              │
+│                                                         │
+│ Error: Cannot find module '@auth/core'                  │
+│ Retry attempts: 1/10                                    │
+│                                                         │
+│ What would you like to do?                              │
+│                                                         │
+│ 1. Retry   - Try this step again                        │
+│ 2. Replan  - Go back to planner to revise the approach  │
+│ 3. Stop    - Stop execution and return to conversation  │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Options**:
+
+| Option | What Happens                                      |
+|--------|---------------------------------------------------|
+| Retry  | Re-run step with failure context + user guidance  |
+| Replan | Send failure details to planner, get revised plan |
+| Stop   | Mark plan as failed, return to conversation       |
+
+**Retry limits**: After 10 retry attempts on the same step, the Retry option is removed. User must Replan or Stop.
+
+## Two-Question Pattern
+
+Plugin-controlled HITL (approval, deviations) uses a consistent two-question pattern:
+
+1. **Action** (`custom: false`) - Deterministic choice from predefined options
+2. **Context** (`custom: true`) - Optional freeform guidance
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Action │ Context │ Confirm                              │
+└─────────────────────────────────────────────────────────┘
+     │         │
+     │         └──► "Try using the v2 API instead"
+     │              (optional freeform input)
+     │
+     └──► Retry / Replan / Stop
+          (must pick one)
+```
+
+**Why this pattern?**
+- **Determinism**: Plugin logic switches on action without parsing freeform text
+- **Flexibility**: Users can still provide nuanced guidance via context
+- **Consistency**: Same UX across all plugin-controlled HITL touchpoints
+
+## HITL Question Schema
+
+All HITL questions follow the same schema:
+
+```typescript
 {
-  "agents": {
-    "coder": {
-      "supervised": true
-    }
-  }
+  header: string           // Tab label (max 30 chars)
+  question: string         // Full question text
+  options: Array<{
+    label: string
+    description?: string
+  }>
+  multiple?: boolean       // Allow multiple selections (default: false)
+  custom?: boolean         // Allow freeform input (default: true)
 }
 ```
 
-### Globally
+The **emitter** (agent or plugin) provides all fields. The HITL system passes through without transformation.
 
-Enable supervision for all agents by default:
+## Read-Only Sessions
 
-```json
-{
-  "settings": {
-    "defaultSupervised": true
-  }
-}
+When agents use `orca_ask_specialist` to ask questions mid-task, the target agent runs in a **read-only session**:
+
+- File write operations are denied
+- Bash commands default to `ask` (user approval required)
+- Known-safe commands (ls, cat, git status, etc.) are auto-allowed
+- Dispatch tools are blocked (prevents recursion)
+
+This allows safe research without risk of side effects.
+
+```typescript
+// Permissions applied to read-only sessions
+const READ_ONLY_PERMISSIONS = [
+  { permission: 'write', pattern: '*', action: 'deny' },
+  { permission: 'edit', pattern: '*', action: 'deny' },
+  { permission: 'bash', pattern: '*', action: 'ask' },
+  { permission: 'bash', pattern: 'ls*', action: 'allow' },
+  { permission: 'bash', pattern: 'git status*', action: 'allow' },
+  // ... other safe read commands
+  { permission: 'read', pattern: '*', action: 'allow' },
+  { permission: 'glob', pattern: '*', action: 'allow' },
+  { permission: 'grep', pattern: '*', action: 'allow' },
+]
 ```
 
-### Resolution Order
+## Future: Automated Supervision
 
-1. Agent's explicit `supervised` setting (if defined)
-2. Global `defaultSupervised` setting (if defined)
-3. Default: `false` (no supervision)
+The current HITL model is the first step toward broader supervision capabilities. Future enhancements may include:
 
-Per-agent settings always take precedence over global defaults.
+- **Watchdog agents** - Automated review of agent actions before execution
+- **Policy-based approval** - Rules that auto-approve or auto-deny based on patterns
+- **Risk scoring** - Automatic assessment of operation risk levels
+- **Audit trails** - Comprehensive logging of all supervised operations
 
-## Checkpoint Flow
-
-1. **Orca dispatches task** to a specialist agent via `orca_dispatch`
-2. **Plugin checks supervision** using `isAgentSupervised()` in dispatch.ts
-3. **If supervised and not pre-approved**, plugin returns a `checkpoint` message
-4. **Orca presents checkpoint** to the user, explaining what will run and why
-5. **User responds** with one of:
-   - Approve this step
-   - Deny this step
-   - Approve all remaining steps in this plan
-6. **If approved**, Orca re-dispatches with `plan_context.approved_remaining: true`
-7. **Agent executes** and returns its response
-
-## Plan Context
-
-The `plan_context` field in task messages tracks approval state across multi-step plans.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `goal` | string | The overall plan objective |
-| `step_index` | number | Current step number (0-based) |
-| `approved_remaining` | boolean | If true, skip checkpoints for remaining steps |
-
-When `approved_remaining` is true, subsequent supervised agents in the same plan execute without additional checkpoints.
-
-## Checkpoint Message Structure
-
-When a checkpoint is returned, the `DispatchResponse` contains a checkpoint message:
-
-| Field        | Type              | Description                    |
-| ------------ | ----------------- | ------------------------------ |
-| `type`         | `'checkpoint'`      | Message type discriminant      |
-| `prompt`       | string            | What the agent would execute   |
-| `step_index`   | number (optional) | Current step in the plan       |
-| `plan_goal`    | string (optional) | Overall objective of the plan  |
-
-The `agent_id` is on the `DispatchResponse` envelope, not on the checkpoint message itself.
-
-## When to Use Supervision
-
-Enable supervision for agents that perform potentially risky operations:
-
-| Use Case | Risk Level | Recommendation |
-|----------|------------|----------------|
-| File modifications (coder) | High | Supervise |
-| Shell command execution | High | Supervise |
-| External API calls | Medium | Consider supervising |
-| Code review (read-only) | Low | Usually not needed |
-| Research (read-only) | Low | Usually not needed |
-
-## Example Configuration
-
-Supervise high-risk agents while allowing read-only agents to run freely:
-
-```json
-{
-  "agents": {
-    "coder": { "supervised": true },
-    "tester": { "supervised": true },
-    "reviewer": { "supervised": false },
-    "researcher": { "supervised": false }
-  }
-}
-```
+These will build on the plan-based model, adding automated gates alongside human ones.
 
 ## See Also
 
+- [Architecture](architecture.md) - System design and agent classes
 - [Configuration](configuration.md) - Full configuration reference
-- [Custom Agents](custom-agents.md) - Creating supervised custom agents
+- [Custom Agents](custom-agents.md) - Creating custom agents

--- a/src/plugin/config.ts
+++ b/src/plugin/config.ts
@@ -44,7 +44,6 @@ export const AgentConfig = z
       .describe('Whether this agent requires approval before dispatch'),
     accepts: z
       .array(QuestionMessage.shape.type.or(TaskMessage.shape.type))
-      .default([])
       .optional()
       .describe(dedent`
         Message types this agent accepts.


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul reflecting the new plan-based execution architecture.

## Changes

### Architecture (`docs/architecture.md`)
- Rewritten to explain thin orchestrator pattern (Orca routes to planner only)
- Documents plan lifecycle: drafting → approval → execution → completed
- Explains context threading (step outputs flow forward)
- Covers HITL supervision model
- Details four dispatch tools: `orca_ask_planner`, `orca_list_plans`, `orca_describe_plan`, `orca_ask_specialist`
- Documents key design decisions

### Supervision (`docs/supervision.md`)
- Updated plan approval HITL flow
- Deviation handling (retry/replan/stop)
- Two-question HITL pattern
- Session-level permissions for read-only research

### Configuration (`docs/configuration.md`)
- New orca/planner restricted config sections
- Plan storage explanation
- Updated examples

### Custom Agents (`docs/custom-agents.md`)
- How agents fit into execution loop
- Tools available to specialists
- Updated examples

### Other
- `docs/README.md`, `docs/getting-started.md`, `docs/troubleshooting.md` - Minor updates for consistency
- `src/plugin/config.ts` - Minor cleanup (1 line removed)

## Testing

Documentation changes only. Verified markdown renders correctly.