### PR TITLE
docs: clarify pm scope for pr creation

### DIFF
--- a/.opencode/agent/product-manager.md
+++ b/.opencode/agent/product-manager.md
@@ -180,4 +180,4 @@ For PRs and releases, use `gh` CLI for reads:
 - `gh pr list`, `gh pr view`
 - `gh release list`, `gh release view`
 
-For PR/release creation, ensure you confirm with the user before creating or updating either.
+For release creation, ensure you confirm with the user before creating or updating.


### PR DESCRIPTION
## Summary
- note PR creation as in-scope for PM (read-only via gh)
- clarify that only PR merging remains outside PM scope